### PR TITLE
Add photo viewing API endpoints for cloud viewer

### DIFF
--- a/packages/cloud/api/main.py
+++ b/packages/cloud/api/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
-from .routers import auth, billing
+from .routers import auth, billing, photo_serve, photos
 
 
 @asynccontextmanager
@@ -47,6 +47,8 @@ def create_app() -> FastAPI:
     # Include routers
     app.include_router(auth.router, prefix="/auth", tags=["auth"])
     app.include_router(billing.router, prefix="/billing", tags=["billing"])
+    app.include_router(photos.router, prefix="/api/photos", tags=["photos"])
+    app.include_router(photo_serve.router, prefix="/photos", tags=["photos"])
 
     return app
 

--- a/packages/cloud/api/routers/photo_serve.py
+++ b/packages/cloud/api/routers/photo_serve.py
@@ -1,0 +1,66 @@
+"""Router for serving photo images at /photos/:path.
+
+This is a separate router to handle the /photos/{path} endpoint that the
+frontend expects for loading images. It requires authentication to verify
+the user has access to the photo.
+"""
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import RedirectResponse
+
+from ..dependencies import CurrentUser, SupabaseClient
+
+router = APIRouter()
+
+
+@router.get("/{path:path}")
+async def serve_photo(
+    path: str,
+    user: CurrentUser,
+    supabase: SupabaseClient,
+):
+    """Serve a photo image by its storage path.
+
+    This endpoint is used by the frontend to serve images.
+    The path should match the image_path returned from GET /api/photos.
+
+    Returns a redirect to a signed Supabase Storage URL (valid for 1 hour).
+    """
+    # Verify the photo belongs to the user by checking the database
+    result = (
+        supabase.table("scored_photos")
+        .select("id")
+        .eq("storage_path", path)
+        .eq("user_id", user.id)
+        .execute()
+    )
+
+    if not result.data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Photo not found or access denied",
+        )
+
+    # Generate signed URL (valid for 1 hour)
+    try:
+        signed_url_response = supabase.storage.from_("photos").create_signed_url(
+            path, expires_in=3600
+        )
+
+        if not signed_url_response or "signedURL" not in signed_url_response:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to generate signed URL",
+            )
+
+        return RedirectResponse(
+            url=signed_url_response["signedURL"],
+            status_code=status.HTTP_302_FOUND,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Storage error: {str(e)}",
+        ) from e

--- a/packages/cloud/api/routers/photos.py
+++ b/packages/cloud/api/routers/photos.py
@@ -1,0 +1,302 @@
+"""Photos router for fetching and serving scored photos."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+from ..dependencies import CurrentUser, SupabaseClient
+
+router = APIRouter()
+
+
+class PhotoResponse(BaseModel):
+    """Scored photo information."""
+
+    id: str
+    image_path: str  # Storage path relative to user folder
+    final_score: float | None
+    aesthetic_score: float | None
+    technical_score: float | None
+    description: str | None
+    explanation: str | None
+    improvements: str | None
+    scene_type: str | None
+    lighting: str | None
+    subject_position: str | None
+    location_name: str | None
+    location_country: str | None
+    features_json: str | None  # JSON string for frontend compatibility
+    qwen_aesthetic: float | None
+    gpt4o_aesthetic: float | None
+    gemini_aesthetic: float | None
+    created_at: datetime
+
+
+class PhotosListResponse(BaseModel):
+    """Paginated list of photos."""
+
+    photos: list[PhotoResponse]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+@router.get("", response_model=PhotosListResponse)
+async def list_photos(
+    user: CurrentUser,
+    supabase: SupabaseClient,
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    sort_by: str = Query(
+        default="created_at", pattern="^(created_at|final_score|aesthetic_score|technical_score)$"
+    ),
+    sort_order: str = Query(default="desc", pattern="^(asc|desc)$"),
+):
+    """Get scored photos for the authenticated user.
+
+    Returns paginated list sorted by the specified field.
+    """
+    # Build query
+    query = supabase.table("scored_photos").select("*", count="exact").eq("user_id", user.id)
+
+    # Apply sorting
+    if sort_order == "desc":
+        query = query.order(sort_by, desc=True)
+    else:
+        query = query.order(sort_by)
+
+    # Apply pagination
+    query = query.range(offset, offset + limit - 1)
+
+    result = query.execute()
+
+    # Get total count
+    total = result.count if result.count is not None else len(result.data)
+
+    # Transform to response format
+    photos = []
+    for row in result.data:
+        # Extract model scores from JSONB if present
+        model_scores = row.get("model_scores") or {}
+
+        photos.append(
+            PhotoResponse(
+                id=row["id"],
+                image_path=row["storage_path"],
+                final_score=row.get("final_score"),
+                aesthetic_score=row.get("aesthetic_score"),
+                technical_score=row.get("technical_score"),
+                description=row.get("description"),
+                explanation=row.get("explanation"),
+                improvements=row.get("improvements"),
+                scene_type=row.get("scene_type"),
+                lighting=row.get("lighting"),
+                subject_position=row.get("subject_position"),
+                location_name=row.get("location_name"),
+                location_country=row.get("location_country"),
+                features_json=str(row.get("features_json")) if row.get("features_json") else None,
+                qwen_aesthetic=model_scores.get("qwen_aesthetic"),
+                gpt4o_aesthetic=model_scores.get("gpt4o_aesthetic"),
+                gemini_aesthetic=model_scores.get("gemini_aesthetic"),
+                created_at=row["created_at"],
+            )
+        )
+
+    return PhotosListResponse(
+        photos=photos,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=offset + len(photos) < total,
+    )
+
+
+@router.get("/{photo_id}", response_model=PhotoResponse)
+async def get_photo(
+    photo_id: str,
+    user: CurrentUser,
+    supabase: SupabaseClient,
+):
+    """Get a single photo by ID."""
+    result = (
+        supabase.table("scored_photos")
+        .select("*")
+        .eq("id", photo_id)
+        .eq("user_id", user.id)
+        .execute()
+    )
+
+    if not result.data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Photo not found",
+        )
+
+    row = result.data[0]
+    model_scores = row.get("model_scores") or {}
+
+    return PhotoResponse(
+        id=row["id"],
+        image_path=row["storage_path"],
+        final_score=row.get("final_score"),
+        aesthetic_score=row.get("aesthetic_score"),
+        technical_score=row.get("technical_score"),
+        description=row.get("description"),
+        explanation=row.get("explanation"),
+        improvements=row.get("improvements"),
+        scene_type=row.get("scene_type"),
+        lighting=row.get("lighting"),
+        subject_position=row.get("subject_position"),
+        location_name=row.get("location_name"),
+        location_country=row.get("location_country"),
+        features_json=str(row.get("features_json")) if row.get("features_json") else None,
+        qwen_aesthetic=model_scores.get("qwen_aesthetic"),
+        gpt4o_aesthetic=model_scores.get("gpt4o_aesthetic"),
+        gemini_aesthetic=model_scores.get("gemini_aesthetic"),
+        created_at=row["created_at"],
+    )
+
+
+@router.delete("/{photo_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_photo(
+    photo_id: str,
+    user: CurrentUser,
+    supabase: SupabaseClient,
+):
+    """Delete a scored photo.
+
+    Also deletes the image from Supabase Storage.
+    """
+    # First get the photo to find storage path
+    result = (
+        supabase.table("scored_photos")
+        .select("storage_path")
+        .eq("id", photo_id)
+        .eq("user_id", user.id)
+        .execute()
+    )
+
+    if not result.data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Photo not found",
+        )
+
+    storage_path = result.data[0]["storage_path"]
+
+    # Delete from storage
+    try:
+        supabase.storage.from_("photos").remove([storage_path])
+    except Exception:
+        # Log but don't fail if storage delete fails
+        pass
+
+    # Delete from database
+    supabase.table("scored_photos").delete().eq("id", photo_id).eq("user_id", user.id).execute()
+
+    return None
+
+
+@router.get("/{photo_id}/image")
+async def get_photo_image(
+    photo_id: str,
+    user: CurrentUser,
+    supabase: SupabaseClient,
+):
+    """Get a signed URL for the photo image.
+
+    Returns a redirect to a signed Supabase Storage URL.
+    The signed URL is valid for 1 hour.
+    """
+    # First verify the photo belongs to the user
+    result = (
+        supabase.table("scored_photos")
+        .select("storage_path")
+        .eq("id", photo_id)
+        .eq("user_id", user.id)
+        .execute()
+    )
+
+    if not result.data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Photo not found",
+        )
+
+    storage_path = result.data[0]["storage_path"]
+
+    # Generate signed URL (valid for 1 hour)
+    try:
+        signed_url_response = supabase.storage.from_("photos").create_signed_url(
+            storage_path, expires_in=3600
+        )
+
+        if not signed_url_response or "signedURL" not in signed_url_response:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to generate signed URL",
+            )
+
+        return RedirectResponse(
+            url=signed_url_response["signedURL"],
+            status_code=status.HTTP_302_FOUND,
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Storage error: {str(e)}",
+        ) from e
+
+
+@router.get("/serve/{path:path}")
+async def serve_photo_by_path(
+    path: str,
+    user: CurrentUser,
+    supabase: SupabaseClient,
+):
+    """Serve a photo by its storage path.
+
+    This endpoint is used by the frontend to serve images directly.
+    The path should be the storage_path from the photo record.
+
+    Returns a redirect to a signed Supabase Storage URL.
+    """
+    # Verify the photo belongs to the user by checking the database
+    result = (
+        supabase.table("scored_photos")
+        .select("id")
+        .eq("storage_path", path)
+        .eq("user_id", user.id)
+        .execute()
+    )
+
+    if not result.data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Photo not found or access denied",
+        )
+
+    # Generate signed URL (valid for 1 hour)
+    try:
+        signed_url_response = supabase.storage.from_("photos").create_signed_url(
+            path, expires_in=3600
+        )
+
+        if not signed_url_response or "signedURL" not in signed_url_response:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to generate signed URL",
+            )
+
+        return RedirectResponse(
+            url=signed_url_response["signedURL"],
+            status_code=status.HTTP_302_FOUND,
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Storage error: {str(e)}",
+        ) from e

--- a/packages/cloud/migrations/003_scored_photos.sql
+++ b/packages/cloud/migrations/003_scored_photos.sql
@@ -1,0 +1,79 @@
+-- Migration: Create scored_photos table for storing photo scoring results
+-- Run this in Supabase SQL Editor after 002_transactions.sql
+
+-- Scored photos table
+CREATE TABLE IF NOT EXISTS scored_photos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    storage_path TEXT NOT NULL,
+    original_filename TEXT,
+
+    -- Scoring results
+    final_score NUMERIC,
+    aesthetic_score NUMERIC,
+    technical_score NUMERIC,
+
+    -- AI-generated content
+    description TEXT,
+    explanation TEXT,
+    improvements TEXT,
+
+    -- Metadata
+    scene_type TEXT,
+    lighting TEXT,
+    subject_position TEXT,
+    location_name TEXT,
+    location_country TEXT,
+
+    -- Detailed scores and features (JSON for flexibility)
+    features_json JSONB,
+    model_scores JSONB,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Ensure unique storage path per user
+    UNIQUE(user_id, storage_path)
+);
+
+-- Trigger to update updated_at on changes
+CREATE OR REPLACE FUNCTION update_scored_photos_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER scored_photos_updated_at
+    BEFORE UPDATE ON scored_photos
+    FOR EACH ROW
+    EXECUTE FUNCTION update_scored_photos_updated_at();
+
+-- Indexes for efficient queries
+CREATE INDEX idx_scored_photos_user ON scored_photos(user_id);
+CREATE INDEX idx_scored_photos_user_created ON scored_photos(user_id, created_at DESC);
+CREATE INDEX idx_scored_photos_user_score ON scored_photos(user_id, final_score DESC);
+
+-- Row-Level Security
+ALTER TABLE scored_photos ENABLE ROW LEVEL SECURITY;
+
+-- Users can view their own photos
+CREATE POLICY "Users can view own photos" ON scored_photos
+    FOR SELECT USING (auth.uid() = user_id);
+
+-- Users can delete their own photos
+CREATE POLICY "Users can delete own photos" ON scored_photos
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- Only service role can insert/update (prevents client manipulation)
+CREATE POLICY "Service role can manage scored_photos" ON scored_photos
+    FOR ALL USING (auth.role() = 'service_role');
+
+-- Comments for documentation
+COMMENT ON TABLE scored_photos IS 'Stores scored photo results for each user';
+COMMENT ON COLUMN scored_photos.storage_path IS 'Path in Supabase Storage (e.g., photos/user-id/image.jpg)';
+COMMENT ON COLUMN scored_photos.final_score IS 'Combined aesthetic + technical score (0-100)';
+COMMENT ON COLUMN scored_photos.features_json IS 'Detailed features extracted by vision models';
+COMMENT ON COLUMN scored_photos.model_scores IS 'Raw scores from each model (qwen, gpt4o, gemini)';

--- a/packages/cloud/tests/test_photos.py
+++ b/packages/cloud/tests/test_photos.py
@@ -1,0 +1,270 @@
+"""Tests for the photos endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from jose import jwt
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Create test client with mocked settings."""
+    # Set required environment variables before importing
+    monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "test-service-key")
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_123")
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "whsec_test_123")
+
+    from api.main import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_token():
+    """Create a valid JWT token for testing."""
+    payload = {
+        "sub": "test-user-123",
+        "email": "test@example.com",
+        "role": "authenticated",
+        "aud": "authenticated",
+    }
+    return jwt.encode(payload, "test-jwt-secret", algorithm="HS256")
+
+
+@pytest.fixture
+def auth_headers(auth_token):
+    """Create authorization headers."""
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+def test_list_photos_requires_auth(client):
+    """Test that photos endpoint requires authentication."""
+    response = client.get("/api/photos")
+    assert response.status_code == 401
+
+
+def test_get_photo_requires_auth(client):
+    """Test that single photo endpoint requires authentication."""
+    response = client.get("/api/photos/some-photo-id")
+    assert response.status_code == 401
+
+
+def test_delete_photo_requires_auth(client):
+    """Test that delete photo endpoint requires authentication."""
+    response = client.delete("/api/photos/some-photo-id")
+    assert response.status_code == 401
+
+
+def test_photo_image_requires_auth(client):
+    """Test that photo image endpoint requires authentication."""
+    response = client.get("/api/photos/some-photo-id/image")
+    assert response.status_code == 401
+
+
+def test_serve_photo_requires_auth(client):
+    """Test that photo serve endpoint requires authentication."""
+    response = client.get("/photos/some/path/image.jpg")
+    assert response.status_code == 401
+
+
+def test_list_photos_pagination_params(client, auth_headers):
+    """Test that list_photos accepts pagination parameters."""
+    # Mock the supabase client
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        # Mock the query chain
+        mock_query = MagicMock()
+        mock_supabase.table.return_value.select.return_value.eq.return_value = mock_query
+        mock_query.order.return_value = mock_query
+        mock_query.range.return_value = mock_query
+        mock_query.execute.return_value = MagicMock(data=[], count=0)
+
+        response = client.get(
+            "/api/photos?limit=10&offset=20&sort_by=final_score&sort_order=asc",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["limit"] == 10
+        assert data["offset"] == 20
+        assert data["photos"] == []
+        assert data["has_more"] is False
+
+
+def test_list_photos_invalid_sort_by(client, auth_headers):
+    """Test that invalid sort_by parameter is rejected."""
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        response = client.get(
+            "/api/photos?sort_by=invalid_field",
+            headers=auth_headers,
+        )
+        assert response.status_code == 422  # Validation error
+
+
+def test_list_photos_invalid_sort_order(client, auth_headers):
+    """Test that invalid sort_order parameter is rejected."""
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        response = client.get(
+            "/api/photos?sort_order=invalid",
+            headers=auth_headers,
+        )
+        assert response.status_code == 422  # Validation error
+
+
+def test_list_photos_limit_validation(client, auth_headers):
+    """Test that limit parameter is validated."""
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        # Too high
+        response = client.get(
+            "/api/photos?limit=500",
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
+
+        # Too low
+        response = client.get(
+            "/api/photos?limit=0",
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
+
+
+def test_list_photos_with_data(client, auth_headers):
+    """Test list_photos returns properly formatted data."""
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        # Sample photo data
+        sample_photo = {
+            "id": "photo-123",
+            "storage_path": "photos/test-user-123/image.jpg",
+            "final_score": 78.5,
+            "aesthetic_score": 0.74,
+            "technical_score": 0.87,
+            "description": "A beautiful landscape",
+            "explanation": "The composition shows strong balance",
+            "improvements": "Consider adjusting exposure",
+            "scene_type": "nature",
+            "lighting": "natural_soft",
+            "subject_position": "rule_of_thirds",
+            "location_name": "Yosemite",
+            "location_country": "USA",
+            "features_json": {"color_palette": "warm"},
+            "model_scores": {"qwen_aesthetic": 0.75, "gpt4o_aesthetic": 0.73},
+            "created_at": "2025-01-01T00:00:00+00:00",
+        }
+
+        # Mock the query chain
+        mock_query = MagicMock()
+        mock_supabase.table.return_value.select.return_value.eq.return_value = mock_query
+        mock_query.order.return_value = mock_query
+        mock_query.range.return_value = mock_query
+        mock_query.execute.return_value = MagicMock(data=[sample_photo], count=1)
+
+        response = client.get("/api/photos", headers=auth_headers)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 1
+        assert len(data["photos"]) == 1
+
+        photo = data["photos"][0]
+        assert photo["id"] == "photo-123"
+        assert photo["image_path"] == "photos/test-user-123/image.jpg"
+        assert photo["final_score"] == 78.5
+        assert photo["qwen_aesthetic"] == 0.75
+        assert photo["gpt4o_aesthetic"] == 0.73
+
+
+def _mock_empty_result(mock_supabase):
+    """Helper to mock an empty database result."""
+    mock_result = MagicMock(data=[])
+    chain = mock_supabase.table.return_value.select.return_value.eq.return_value.eq.return_value
+    chain.execute.return_value = mock_result
+
+
+def test_get_photo_not_found(client, auth_headers):
+    """Test get_photo returns 404 for non-existent photo."""
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        # Mock empty result
+        _mock_empty_result(mock_supabase)
+
+        response = client.get("/api/photos/nonexistent-id", headers=auth_headers)
+        assert response.status_code == 404
+        assert "Photo not found" in response.json()["detail"]
+
+
+def test_delete_photo_not_found(client, auth_headers):
+    """Test delete_photo returns 404 for non-existent photo."""
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        # Mock empty result
+        _mock_empty_result(mock_supabase)
+
+        response = client.delete("/api/photos/nonexistent-id", headers=auth_headers)
+        assert response.status_code == 404
+
+
+def test_serve_photo_not_found(client, auth_headers):
+    """Test serve_photo returns 404 for non-existent photo."""
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        # Mock empty result
+        _mock_empty_result(mock_supabase)
+
+        response = client.get(
+            "/photos/nonexistent/path.jpg",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+        assert response.status_code == 404
+        assert "Photo not found" in response.json()["detail"]
+
+
+def test_serve_photo_redirect(client, auth_headers):
+    """Test serve_photo redirects to signed URL."""
+    with patch("api.dependencies.create_client") as mock_create:
+        mock_supabase = MagicMock()
+        mock_create.return_value = mock_supabase
+
+        # Mock photo exists
+        mock_result = MagicMock(data=[{"id": "photo-123"}])
+        chain = mock_supabase.table.return_value.select.return_value.eq.return_value.eq.return_value
+        chain.execute.return_value = mock_result
+
+        # Mock signed URL generation
+        mock_supabase.storage.from_.return_value.create_signed_url.return_value = {
+            "signedURL": "https://storage.supabase.co/signed-url-here"
+        }
+
+        response = client.get(
+            "/photos/photos/test-user-123/image.jpg",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.headers["location"] == "https://storage.supabase.co/signed-url-here"


### PR DESCRIPTION
## Summary

- Add `scored_photos` table migration with RLS policies for secure per-user photo storage
- Implement `GET /api/photos` endpoint with pagination and sorting (by score, date, etc.)
- Implement `GET /api/photos/{id}` for single photo retrieval
- Implement `DELETE /api/photos/{id}` to remove photos from database and storage
- Add `GET /photos/{path}` endpoint for serving images via signed Supabase Storage URLs
- Include comprehensive test coverage for all endpoints

## New Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/photos` | List user's scored photos (paginated, sortable) |
| GET | `/api/photos/{id}` | Get single photo details |
| GET | `/api/photos/{id}/image` | Get signed URL for photo image |
| DELETE | `/api/photos/{id}` | Delete photo from DB and storage |
| GET | `/photos/{path}` | Serve photo by storage path (frontend-compatible) |

## Database Migration

New `scored_photos` table stores all scored photo data:
- User ID with foreign key to auth.users
- Scoring results (final, aesthetic, technical)
- AI-generated content (description, explanation, improvements)
- Metadata (scene type, lighting, location)
- JSONB fields for model scores and features
- RLS policies for secure user-scoped access

## Test plan

- [x] All new photo endpoint tests pass (14 tests)
- [x] All existing tests pass (26 tests)
- [x] Ruff linting passes
- [ ] Manual test: Deploy to Render and verify endpoints
- [ ] Manual test: Run migration in Supabase
- [ ] Manual test: Vercel frontend can load photos from cloud API

## Deployment Notes

After merging:
1. Run the SQL migration (`003_scored_photos.sql`) in Supabase SQL Editor
2. Create a `photos` storage bucket in Supabase Storage
3. Deploy updated API to Render

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)