### PR TITLE
Fix production API routing - use VITE_API_URL for cross-origin requests

### DIFF
--- a/packages/cloud/api/main.py
+++ b/packages/cloud/api/main.py
@@ -44,10 +44,10 @@ def create_app() -> FastAPI:
         """Health check endpoint for Railway deployment."""
         return {"status": "healthy", "version": "0.1.0"}
 
-    # Include routers
-    app.include_router(auth.router, prefix="/auth", tags=["auth"])
-    app.include_router(billing.router, prefix="/billing", tags=["billing"])
-    app.include_router(inference.router, prefix="/inference", tags=["inference"])
+    # Include routers - all API routes under /api prefix
+    app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
+    app.include_router(billing.router, prefix="/api/billing", tags=["billing"])
+    app.include_router(inference.router, prefix="/api/inference", tags=["inference"])
     app.include_router(photos.router, prefix="/api/photos", tags=["photos"])
     app.include_router(photo_serve.router, prefix="/photos", tags=["photos"])
 

--- a/packages/cloud/tests/test_billing.py
+++ b/packages/cloud/tests/test_billing.py
@@ -26,7 +26,7 @@ def client(monkeypatch):
 
 def test_get_plans(client):
     """Test listing available credit plans."""
-    response = client.get("/billing/plans")
+    response = client.get("/api/billing/plans")
     assert response.status_code == 200
 
     plans = response.json()
@@ -48,20 +48,20 @@ def test_get_plans(client):
 
 def test_get_balance_requires_auth(client):
     """Test that balance endpoint requires authentication."""
-    response = client.get("/billing/balance")
+    response = client.get("/api/billing/balance")
     assert response.status_code == 401  # No auth header - returns 401 Unauthorized
 
 
 def test_get_transactions_requires_auth(client):
     """Test that transactions endpoint requires authentication."""
-    response = client.get("/billing/transactions")
+    response = client.get("/api/billing/transactions")
     assert response.status_code == 401  # No auth header - returns 401 Unauthorized
 
 
 def test_checkout_requires_auth(client):
     """Test that checkout endpoint requires authentication."""
     response = client.post(
-        "/billing/checkout",
+        "/api/billing/checkout",
         json={
             "plan_id": "credits_100",
             "success_url": "https://example.com/success",
@@ -73,7 +73,7 @@ def test_checkout_requires_auth(client):
 
 def test_webhook_requires_signature(client):
     """Test that webhook endpoint requires Stripe signature."""
-    response = client.post("/billing/webhook", content=b"{}")
+    response = client.post("/api/billing/webhook", content=b"{}")
     assert response.status_code == 400
     assert "Missing Stripe-Signature" in response.json()["detail"]
 
@@ -81,7 +81,7 @@ def test_webhook_requires_signature(client):
 def test_webhook_rejects_invalid_signature(client):
     """Test that webhook rejects invalid signatures."""
     response = client.post(
-        "/billing/webhook",
+        "/api/billing/webhook",
         content=b'{"type": "test"}',
         headers={"Stripe-Signature": "t=123,v1=invalid"},
     )

--- a/packages/cloud/tests/test_inference.py
+++ b/packages/cloud/tests/test_inference.py
@@ -33,7 +33,7 @@ TINY_JPEG = base64.b64encode(
 def test_analyze_requires_auth(client):
     """Test that inference/analyze requires authentication."""
     response = client.post(
-        "/inference/analyze",
+        "/api/inference/analyze",
         json={"image_data": TINY_JPEG},
     )
     assert response.status_code == 401
@@ -42,7 +42,7 @@ def test_analyze_requires_auth(client):
 def test_metadata_requires_auth(client):
     """Test that inference/metadata requires authentication."""
     response = client.post(
-        "/inference/metadata",
+        "/api/inference/metadata",
         json={"image_data": TINY_JPEG},
     )
     assert response.status_code == 401
@@ -51,7 +51,7 @@ def test_metadata_requires_auth(client):
 def test_analyze_invalid_base64(client, auth_token):
     """Test that invalid base64 returns 400."""
     response = client.post(
-        "/inference/analyze",
+        "/api/inference/analyze",
         json={"image_data": "not-valid-base64!!!"},
         headers={"Authorization": f"Bearer {auth_token}"},
     )

--- a/packages/web/src/contexts/AuthContext.tsx
+++ b/packages/web/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import type { User, Session, AuthError, Provider } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
+import { apiFetch } from '../lib/api';
 
 interface AuthContextType {
   user: User | null;
@@ -34,7 +35,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Fetch user info (and trigger trial credit grant for new users)
   const fetchUserInfo = useCallback(async (accessToken: string) => {
     try {
-      const response = await fetch('/api/auth/me', {
+      const response = await apiFetch('/api/auth/me', {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },

--- a/packages/web/src/hooks/usePhotos.ts
+++ b/packages/web/src/hooks/usePhotos.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { Photo } from '../types/photo';
+import { apiFetch } from '../lib/api';
 
 interface UsePhotosResult {
   photos: Photo[];
@@ -24,7 +25,7 @@ export function usePhotos(): UsePhotosResult {
           return;
         }
 
-        const response = await fetch('/api/photos');
+        const response = await apiFetch('/api/photos');
         if (!response.ok) {
           throw new Error(`Failed to fetch photos: ${response.statusText}`);
         }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,0 +1,20 @@
+/**
+ * API client with configurable base URL.
+ * In development, uses Vite proxy (/api).
+ * In production, uses VITE_API_URL environment variable.
+ */
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || '';
+
+export function apiUrl(path: string): string {
+  // Ensure path starts with /
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${API_BASE_URL}${normalizedPath}`;
+}
+
+export async function apiFetch(
+  path: string,
+  options?: RequestInit
+): Promise<Response> {
+  return fetch(apiUrl(path), options);
+}

--- a/packages/web/src/pages/Upload.tsx
+++ b/packages/web/src/pages/Upload.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { apiFetch } from '../lib/api';
 
 interface UploadFile {
   file: File;
@@ -110,7 +111,7 @@ export function Upload() {
         formData.append('file', uploadFile.file);
 
         // Upload to backend
-        const response = await fetch('/api/photos/upload', {
+        const response = await apiFetch('/api/photos/upload', {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${session.access_token}`,
@@ -138,7 +139,7 @@ export function Upload() {
         });
 
         // Trigger scoring
-        const scoreResponse = await fetch(`/api/photos/${result.id}/score`, {
+        const scoreResponse = await apiFetch(`/api/photos/${result.id}/score`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${session.access_token}`,

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -5,6 +5,7 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  envDir: '../..',  // Load .env from monorepo root
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- Add `VITE_API_URL` environment variable for production API base URL
- Create `api.ts` client with configurable base URL
- Update all fetch calls to use `apiFetch()` helper
- Standardize backend routes under `/api` prefix
- Update tests for new route paths
- Configure Vite to load env from monorepo root

## Why
In production, the frontend (Vercel) and backend (Render) are on different domains. The frontend was making requests to `/api/photos/upload` which hit Vercel instead of Render, causing 405 errors.

## Test plan
- [x] All tests pass
- [ ] Verify upload works in production after deploy
- [ ] Add `VITE_API_URL=https://photo-score-api.onrender.com` to Vercel env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)