### PR TITLE
Add lightbox with reprocess button for cloud implementation

### DIFF
--- a/packages/web/src/components/PhotoCard.tsx
+++ b/packages/web/src/components/PhotoCard.tsx
@@ -8,7 +8,7 @@ import { Expandable } from './Expandable';
 interface PhotoCardProps {
   photo: Photo;
   correction?: Correction;
-  onImageClick: (src: string) => void;
+  onImageClick: (photo: Photo) => void;
   onCorrectionUpdate: (
     field: keyof Correction,
     value: string | number,
@@ -81,13 +81,22 @@ export function PhotoCard({
         <img
           src={imageSrc}
           alt={photo.image_path}
-          onClick={() => onImageClick(imageSrc)}
+          onClick={() => {
+            console.log('Image clicked, photo:', photo);
+            onImageClick(photo);
+          }}
           onError={() => setImageError(true)}
           loading="lazy"
           className="w-full h-[300px] object-cover cursor-pointer bg-[var(--bg-tertiary)]"
         />
       ) : (
-        <div className="w-full h-[300px] bg-[var(--bg-tertiary)] flex items-center justify-center">
+        <div
+          className="w-full h-[300px] bg-[var(--bg-tertiary)] flex items-center justify-center cursor-pointer"
+          onClick={() => {
+            console.log('Placeholder clicked, photo:', photo);
+            onImageClick(photo);
+          }}
+        >
           <div className="text-center text-[var(--text-muted)]">
             <svg className="w-12 h-12 mx-auto mb-2 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />

--- a/packages/web/src/components/PhotoGrid.tsx
+++ b/packages/web/src/components/PhotoGrid.tsx
@@ -4,7 +4,7 @@ import { PhotoCard } from './PhotoCard';
 interface PhotoGridProps {
   photos: Photo[];
   corrections: Record<string, Correction>;
-  onImageClick: (src: string) => void;
+  onImageClick: (photo: Photo) => void;
   onCorrectionUpdate: (
     imagePath: string,
     field: keyof Correction,
@@ -23,7 +23,7 @@ export function PhotoGrid({
     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-5 max-w-[1800px] mx-auto">
       {photos.map((photo) => (
         <PhotoCard
-          key={photo.image_path}
+          key={photo.id || photo.image_path}
           photo={photo}
           correction={corrections[photo.image_path]}
           onImageClick={onImageClick}

--- a/packages/web/src/hooks/usePhotos.ts
+++ b/packages/web/src/hooks/usePhotos.ts
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 
 interface UsePhotosResult {
   photos: Photo[];
+  setPhotos: React.Dispatch<React.SetStateAction<Photo[]>>;
   loading: boolean;
   error: string | null;
   refetch: () => void;
@@ -53,5 +54,5 @@ export function usePhotos(): UsePhotosResult {
     fetchPhotos();
   }, [session?.access_token]);
 
-  return { photos, loading, error, refetch: fetchPhotos };
+  return { photos, setPhotos, loading, error, refetch: fetchPhotos };
 }


### PR DESCRIPTION
## Summary
- Add functional lightbox that opens when clicking photo thumbnails in the dashboard
- Add "Regenerate Critique" button in lightbox to reprocess photos via `/api/photos/{id}/regenerate`
- Fix image display using signed URLs from `image_url` field
- Add placeholder for unavailable images (both in grid and lightbox)
- Handle null scores gracefully

## Changes
- **Lightbox.tsx**: Added reprocess functionality, fixed image URL usage, added placeholder
- **PhotoCard.tsx**: Pass Photo object on click instead of URL, added click handler to placeholder
- **PhotoGrid.tsx**: Updated onImageClick signature to accept Photo
- **Dashboard.tsx**: Find photo by ID instead of URL matching, pass onPhotoUpdated callback
- **usePhotos.ts**: Expose setPhotos to allow updating individual photos

## Test plan
- [ ] Upload a photo and verify it appears in the dashboard
- [ ] Click on the photo thumbnail to open the lightbox
- [ ] Verify photo details (score, critique, improvements) are displayed
- [ ] Click "Regenerate Critique" button and verify it updates the content
- [ ] Use arrow keys to navigate between photos (if multiple)
- [ ] Press ESC or click outside to close lightbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)