### PR TITLE
Implement rich critique generation matching CLI quality

### DIFF
--- a/packages/cloud/migrations/005_features_cache.sql
+++ b/packages/cloud/migrations/005_features_cache.sql
@@ -1,0 +1,36 @@
+-- Migration: 005_features_cache
+-- Description: Add cache table for scene features (for rich critique generation)
+-- Created: 2025-01-01
+
+-- Table for caching extracted scene features
+CREATE TABLE IF NOT EXISTS features_cache (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    image_hash VARCHAR(64) NOT NULL,  -- SHA256 hash
+    features JSONB NOT NULL,  -- Scene features (scene_type, main_subject, lighting, etc.)
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Unique constraint: one result per user+image combination
+    UNIQUE(user_id, image_hash)
+);
+
+-- Index for efficient lookups
+CREATE INDEX IF NOT EXISTS idx_features_cache_user_hash
+    ON features_cache(user_id, image_hash);
+
+-- RLS policies
+ALTER TABLE features_cache ENABLE ROW LEVEL SECURITY;
+
+-- Users can only access their own cache entries
+CREATE POLICY "Users can view own features cache"
+    ON features_cache FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own features cache"
+    ON features_cache FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+-- Service role bypass for backend operations
+CREATE POLICY "Service role full access features_cache"
+    ON features_cache FOR ALL
+    USING (auth.jwt() ->> 'role' = 'service_role');

--- a/packages/cloud/pyproject.toml
+++ b/packages/cloud/pyproject.toml
@@ -38,6 +38,10 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+# Ignore line length in openrouter.py - contains multi-line LLM prompts
+"api/services/openrouter.py" = ["E501"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/packages/cloud/scripts/integration_test.py
+++ b/packages/cloud/scripts/integration_test.py
@@ -19,11 +19,11 @@ import argparse
 import base64
 import os
 import sys
+from io import BytesIO
 from pathlib import Path
 
 import httpx
 from PIL import Image
-from io import BytesIO
 
 
 def create_test_image() -> bytes:
@@ -225,7 +225,7 @@ def main():
     api_url = args.api_url.rstrip("/")
 
     print(f"\n{'=' * 60}")
-    print(f"Integration Test for Photo Score API")
+    print("Integration Test for Photo Score API")
     print(f"API URL: {api_url}")
     print(f"{'=' * 60}")
 

--- a/packages/cloud/tests/conftest_integration.py
+++ b/packages/cloud/tests/conftest_integration.py
@@ -493,3 +493,88 @@ def cleanup_storage(supabase_admin, test_user):
             supabase_admin.storage.from_("photos").remove(paths)
     except Exception:
         pass
+
+
+@pytest.fixture
+def mock_openrouter(monkeypatch):
+    """Mock all OpenRouter service methods to avoid API calls.
+
+    Returns mock responses that simulate rich critique generation.
+    """
+    from api.services import openrouter
+
+    async def mock_analyze_image(self, image_data, image_hash):
+        return {
+            "composition": 0.7,
+            "subject_strength": 0.8,
+            "visual_appeal": 0.75,
+            "sharpness": 0.9,
+            "exposure_balance": 0.85,
+            "noise_level": 0.1,
+        }
+
+    async def mock_analyze_metadata(self, image_data, image_hash):
+        return {
+            "description": "A test photograph showing a landscape scene.",
+            "location_name": "Test Location",
+            "location_country": "Test Country",
+        }
+
+    async def mock_extract_features(self, image_data):
+        return {
+            "scene_type": "landscape",
+            "main_subject": "mountain range with dramatic sky",
+            "subject_position": "center",
+            "background": "clean",
+            "lighting": "golden_hour",
+            "color_palette": "warm",
+            "depth_of_field": "deep",
+            "motion": "static",
+            "human_presence": "none",
+            "text_or_signs": False,
+            "weather_visible": "clear",
+            "time_of_day": "golden_hour",
+            "technical_issues": [],
+            "notable_elements": ["dramatic clouds", "mountain peaks", "warm light"],
+            "estimated_location_type": "mountain",
+        }
+
+    async def mock_generate_critique(self, image_data, features, attributes, final_score):
+        return {
+            "summary": (
+                "This landscape photograph captures a stunning mountain scene with excellent "
+                "golden hour lighting. The composition effectively uses the rule of thirds, "
+                "though the foreground could benefit from a stronger anchor element."
+            ),
+            "working_well": [
+                "The golden hour lighting creates beautiful warm tones across the mountain "
+                "peaks, adding depth and dimension to the scene.",
+                "Strong technical execution with excellent sharpness throughout the frame "
+                "and well-controlled exposure in the challenging lighting conditions.",
+            ],
+            "could_improve": [
+                "The foreground lacks a compelling anchor element - consider including "
+                "rocks, flowers, or leading lines to draw the viewer into the scene.",
+                "The horizon is placed near the center; try positioning it on the upper "
+                "or lower third for a more dynamic composition.",
+            ],
+            "key_recommendation": (
+                "Return during different lighting conditions or find a foreground element "
+                "like interesting rocks or wildflowers to create depth and lead the "
+                "viewer's eye through the frame."
+            ),
+        }
+
+    monkeypatch.setattr(openrouter.OpenRouterService, "analyze_image", mock_analyze_image)
+    monkeypatch.setattr(
+        openrouter.OpenRouterService, "analyze_image_metadata", mock_analyze_metadata
+    )
+    monkeypatch.setattr(openrouter.OpenRouterService, "extract_features", mock_extract_features)
+    monkeypatch.setattr(openrouter.OpenRouterService, "generate_critique", mock_generate_critique)
+
+    return {
+        "analyze_image": mock_analyze_image,
+        "analyze_metadata": mock_analyze_metadata,
+        "extract_features": mock_extract_features,
+        "generate_critique": mock_generate_critique,
+    }

--- a/packages/cloud/tests/test_inference.py
+++ b/packages/cloud/tests/test_inference.py
@@ -164,6 +164,92 @@ class TestOpenRouterService:
         assert decoded == original
 
 
+class TestCritiqueFormatting:
+    """Tests for critique formatting methods."""
+
+    def test_format_explanation(self, monkeypatch):
+        """Test that format_explanation produces structured output."""
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_KEY", FAKE_SERVICE_JWT)
+        monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+        from api.services.openrouter import OpenRouterService
+
+        critique = {
+            "summary": "This is a well-composed landscape shot with good lighting.",
+            "working_well": [
+                "Strong composition with rule of thirds placement.",
+                "Excellent golden hour lighting adds warmth.",
+            ],
+            "could_improve": [
+                "Consider adding foreground interest.",
+                "The horizon could be straighter.",
+            ],
+            "key_recommendation": "Return at sunset for more dramatic light.",
+        }
+
+        explanation = OpenRouterService.format_explanation(critique)
+
+        assert "This is a well-composed landscape shot" in explanation
+        assert "**What's working:**" in explanation
+        assert "Strong composition" in explanation
+        assert "**Could improve:**" in explanation
+        assert "foreground interest" in explanation
+
+    def test_format_explanation_empty_critique(self, monkeypatch):
+        """Test that format_explanation handles empty critique gracefully."""
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_KEY", FAKE_SERVICE_JWT)
+        monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+        from api.services.openrouter import OpenRouterService
+
+        critique = {}
+        explanation = OpenRouterService.format_explanation(critique)
+
+        assert explanation == "Unable to generate critique."
+
+    def test_format_improvements(self, monkeypatch):
+        """Test that format_improvements extracts key recommendation."""
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_KEY", FAKE_SERVICE_JWT)
+        monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+        from api.services.openrouter import OpenRouterService
+
+        critique = {
+            "could_improve": [
+                "Add foreground interest.",
+                "Straighten the horizon.",
+            ],
+            "key_recommendation": "Return at sunset for dramatic light.",
+        }
+
+        improvements = OpenRouterService.format_improvements(critique)
+
+        assert "Add foreground interest." in improvements
+        assert "Straighten the horizon." in improvements
+        assert "**Key recommendation:**" in improvements
+        assert "sunset" in improvements
+
+    def test_format_improvements_empty(self, monkeypatch):
+        """Test that format_improvements handles empty critique."""
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_KEY", FAKE_SERVICE_JWT)
+        monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+        from api.services.openrouter import OpenRouterService
+
+        critique = {}
+        improvements = OpenRouterService.format_improvements(critique)
+
+        assert improvements == "No specific improvements identified."
+
+
 class TestRateLimiting:
     """Tests for rate limiting."""
 


### PR DESCRIPTION
## Summary

Closes #55

The cloud backend was producing generic template-based critiques like:
```
**Near-publishable**. Strong sharpness and low noise.
```

While the CLI produced rich, contextual feedback like:
```
This macro shot successfully utilizes a shallow depth of field to isolate delicate floral details against a dramatic, mountainous backdrop...

**What's working:** The shallow depth of field effectively separates the intricate textures of the flower from the busy background...

**Could improve:** The focus is slightly soft on the main open flower; in macro photography, ensuring the 'eye' or center of the bloom is tack-sharp is critical...
```

This PR updates the cloud backend to match CLI quality by implementing:

1. **Feature extraction** - Extracts scene context (scene_type, lighting, subject, background, etc.) using Haiku
2. **Critique generation** - Generates rich, contextual critique using Sonnet with full context (features + scores)
3. **Structured formatting** - Formats output with summary, "What's working", "Could improve", and "Key recommendation" sections

## Changes

- `api/services/openrouter.py`:
  - Add `FEATURE_EXTRACTION_PROMPT` and `CRITIQUE_PROMPT_TEMPLATE`
  - Add `extract_features()` async method
  - Add `generate_critique()` async method
  - Replace template-based `generate_explanation()` and `generate_improvements()` with `format_explanation()` and `format_improvements()` that use critique dict

- `api/routers/photos.py`:
  - Update `score_photo` endpoint to extract features -> compute scores -> generate critique
  - Add features_cache lookup and storage
  - Update `regenerate_explanation` endpoint to generate rich critiques
  - Update `regenerate-all` endpoint similarly

- `migrations/005_features_cache.sql`:
  - New cache table for extracted scene features

- Tests:
  - Add `mock_openrouter` fixture with all mocked methods
  - Add `test_score_photo_generates_rich_critique` test
  - Add `test_score_photo_stores_features` test
  - Add `TestCritiqueFormatting` unit tests for format methods
  - Update existing tests to use new fixture

## Cost Impact

| Call | Model | Cost/image |
|------|-------|------------|
| Feature extraction | Haiku | ~$0.0005 |
| Critique generation | Sonnet | ~$0.002 |
| **Total additional** | | **~$0.0025** |

Current cost: ~$0.005/image → New cost: ~$0.0075/image (+50%)

## Test plan

- [x] All 59 unit tests pass
- [x] All 26 CLI tests pass
- [x] Lint passes
- [ ] Integration tests (requires local Supabase)
- [ ] Manual test with real images to verify critique quality

## Quality validation

The new tests verify:
- Explanation length > 100 chars (not template output)
- Contains "**What's working:**" section
- Contains "**Could improve:**" section
- Does NOT contain old template phrases like "Near-publishable" or "Tourist-level"
- Improvements contain "Key recommendation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)