### PR TITLE
Add duplicate photo detection on upload

### DIFF
--- a/packages/api/migrations/007_photo_image_hash.sql
+++ b/packages/api/migrations/007_photo_image_hash.sql
@@ -1,0 +1,13 @@
+-- Migration: 007_photo_image_hash
+-- Description: Add image_hash column to scored_photos for deduplication
+-- Created: 2026-01-03
+
+-- Add image_hash column to scored_photos table
+ALTER TABLE scored_photos ADD COLUMN IF NOT EXISTS image_hash VARCHAR(64);
+
+-- Create index for efficient duplicate lookups
+CREATE INDEX IF NOT EXISTS idx_scored_photos_user_hash
+    ON scored_photos(user_id, image_hash);
+
+-- Note: We don't add a UNIQUE constraint because existing duplicates may exist.
+-- The application logic handles deduplication on upload.


### PR DESCRIPTION
## Summary
This PR includes several improvements:

### 1. Duplicate Photo Detection on Upload
- When a user uploads the same image (by content hash), return the existing photo instead of creating a duplicate
- Prevents wasted storage and duplicate entries in the database
- Stores SHA256 hash of image content in `scored_photos.image_hash` column

### 2. Cleanup Script for Existing Duplicates
- `scripts/dedupe_photos.py` to backfill hashes and remove existing duplicates
- Keeps the oldest scored photo, deletes the rest
- Cleans up both database records and storage files

### 3. UX Smoke Tests
- Automated smoke tests to verify critical API user flows
- Tests health endpoints, auth, photo listing, rescore, credits, error handling
- Includes Claude Code skill `/ux-test` for easy execution

## Changes
- `api/routers/photos.py` - Duplicate detection on upload
- `migrations/007_photo_image_hash.sql` - Add image_hash column
- `scripts/dedupe_photos.py` - Cleanup script for existing duplicates
- `tests/ux_smoke_test.py` - UX smoke test runner
- `tests/ux_test_checklist.md` - Manual testing checklist
- `.claude/commands/ux-test.md` - Claude Code skill

## Migration Required
Run this SQL in Supabase after merging:
```sql
ALTER TABLE scored_photos ADD COLUMN IF NOT EXISTS image_hash VARCHAR(64);
CREATE INDEX IF NOT EXISTS idx_scored_photos_user_hash ON scored_photos(user_id, image_hash);
```

## Test plan
- [x] Migration run in Supabase
- [x] Dedupe script tested with --dry-run
- [x] Dedupe script run successfully (5 duplicates removed)
- [ ] Upload a new photo - should create new record with image_hash
- [ ] Upload the same photo again - should return existing photo
- [ ] Run UX smoke tests against API

🤖 Generated with [Claude Code](https://claude.com/claude-code)