### PR TITLE
Implement server-side scoring queue for background processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,9 @@ photo_scores_corrected_*.csv
 Thumbs.db
 
 # Local Supabase development
-supabase/
+supabase/.branches
+supabase/.temp
+# Keep functions and migrations tracked
+!supabase/functions/
+!supabase/migrations/
+!supabase/config.toml

--- a/packages/api/api/config.py
+++ b/packages/api/api/config.py
@@ -40,6 +40,14 @@ class Settings(BaseSettings):
         "https://photo-scoring.spraiandprai.com",
     ]
 
+    # Internal API key for Edge Functions (defaults to service key if not set)
+    internal_api_key: str = ""
+
+    @property
+    def get_internal_api_key(self) -> str:
+        """Get the internal API key for Edge Function authentication."""
+        return self.internal_api_key or self.supabase_service_key
+
     @property
     def supabase_anon_key(self) -> str:
         """For client-side operations that don't need service key."""

--- a/packages/api/migrations/008_scoring_queue.sql
+++ b/packages/api/migrations/008_scoring_queue.sql
@@ -1,0 +1,69 @@
+-- Migration: 008_scoring_queue
+-- Description: Add scoring queue table for background processing
+-- Created: 2025-01-04
+
+-- Table for queuing photo scoring jobs
+CREATE TABLE IF NOT EXISTS scoring_queue (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    photo_id UUID NOT NULL REFERENCES scored_photos(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    priority INT DEFAULT 0,  -- Higher priority processed first
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    error_message TEXT,
+    retry_count INT DEFAULT 0,
+
+    -- One queue entry per photo
+    UNIQUE(photo_id)
+);
+
+-- Indexes for efficient queue processing
+CREATE INDEX IF NOT EXISTS idx_scoring_queue_status_priority
+    ON scoring_queue(status, priority DESC, created_at ASC)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_scoring_queue_user
+    ON scoring_queue(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_scoring_queue_photo
+    ON scoring_queue(photo_id);
+
+-- RLS policies
+ALTER TABLE scoring_queue ENABLE ROW LEVEL SECURITY;
+
+-- Users can view their own queue entries
+CREATE POLICY "Users can view own queue entries"
+    ON scoring_queue FOR SELECT
+    USING (auth.uid() = user_id);
+
+-- Users can insert their own queue entries
+CREATE POLICY "Users can insert own queue entries"
+    ON scoring_queue FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+-- Service role has full access (for background processing)
+CREATE POLICY "Service role full access scoring_queue"
+    ON scoring_queue FOR ALL
+    USING (auth.jwt() ->> 'role' = 'service_role');
+
+-- Function to notify when new job is added to queue
+CREATE OR REPLACE FUNCTION notify_scoring_queue_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify('scoring_queue_insert', json_build_object(
+        'id', NEW.id,
+        'user_id', NEW.user_id,
+        'photo_id', NEW.photo_id
+    )::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to call notification function on insert
+DROP TRIGGER IF EXISTS scoring_queue_insert_trigger ON scoring_queue;
+CREATE TRIGGER scoring_queue_insert_trigger
+    AFTER INSERT ON scoring_queue
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_scoring_queue_insert();

--- a/packages/api/migrations/009_scoring_queue_webhook.sql
+++ b/packages/api/migrations/009_scoring_queue_webhook.sql
@@ -1,0 +1,63 @@
+-- Migration: 009_scoring_queue_webhook
+-- Description: Configure webhook to trigger Edge Function on queue insert
+-- Created: 2025-01-04
+--
+-- NOTE: This migration creates a database webhook to trigger the
+-- process-scoring-queue Edge Function when new jobs are added.
+--
+-- For Supabase hosted:
+-- - The webhook is configured in the Supabase Dashboard under Database > Webhooks
+-- - The Edge Function URL would be: https://<project>.supabase.co/functions/v1/process-scoring-queue
+--
+-- For local development:
+-- - Use `supabase functions serve` to run the Edge Function locally
+-- - Configure cron or manual triggers to process the queue
+--
+-- The pg_notify trigger created in 008_scoring_queue.sql can be used
+-- with pg_listen in a worker process as an alternative to webhooks.
+
+-- Create a helper function to get the Edge Function URL
+-- This is configured as a secret/setting in Supabase
+CREATE OR REPLACE FUNCTION get_edge_function_url(function_name TEXT)
+RETURNS TEXT AS $$
+BEGIN
+    -- In production, this would return the actual Edge Function URL
+    -- For now, return a placeholder that can be configured
+    RETURN COALESCE(
+        current_setting('app.edge_function_base_url', TRUE),
+        'http://localhost:54321/functions/v1'
+    ) || '/' || function_name;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Add comment explaining the webhook setup
+COMMENT ON FUNCTION notify_scoring_queue_insert() IS
+'Emits pg_notify event when a new scoring job is added.
+This can be used by:
+1. Supabase Database Webhooks (configure in Dashboard)
+2. A pg_listen worker process
+3. Polling the queue table
+
+For production, configure a Database Webhook in Supabase Dashboard:
+- Table: scoring_queue
+- Events: INSERT
+- Webhook URL: https://<project>.supabase.co/functions/v1/process-scoring-queue
+- HTTP Method: POST
+- Headers: Authorization: Bearer <service-role-key>';
+
+-- Alternative: Create a cron job to process the queue periodically
+-- This requires pg_cron extension (available on Supabase Pro)
+--
+-- CREATE EXTENSION IF NOT EXISTS pg_cron;
+--
+-- SELECT cron.schedule(
+--     'process-scoring-queue',
+--     '*/1 * * * *',  -- Every minute
+--     $$
+--     SELECT net.http_post(
+--         url := get_edge_function_url('process-scoring-queue'),
+--         headers := '{"Content-Type": "application/json"}'::jsonb,
+--         body := '{}'::jsonb
+--     )
+--     $$
+-- );

--- a/packages/webapp/src/components/CorrectionForm.tsx
+++ b/packages/webapp/src/components/CorrectionForm.tsx
@@ -45,7 +45,7 @@ export function CorrectionForm({
   correction,
   onUpdate,
 }: CorrectionFormProps) {
-  const scoreValue = correction?.score ?? Math.round(photo.final_score);
+  const scoreValue = correction?.score ?? Math.round(photo.final_score ?? 0);
   const compositionValue =
     correction?.composition ?? Math.round((photo.composition || 0) * 100);
   const subjectValue =

--- a/packages/webapp/src/components/PhotoCard.tsx
+++ b/packages/webapp/src/components/PhotoCard.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import type { Photo, Correction, PhotoFeatures } from '../types/photo';
-import { getScoreLevel, getScoreLabel } from '../types/photo';
+import { getScoreLevel, getScoreLabel, isScored } from '../types/photo';
 import { ScoreBreakdown } from './ScoreBreakdown';
 import { CorrectionForm } from './CorrectionForm';
 import { Expandable } from './Expandable';
@@ -41,6 +41,7 @@ const scoreColorClasses: Record<string, string> = {
   competent: 'text-[#facc15]',
   tourist: 'text-[#fb923c]',
   flawed: 'text-[#f87171]',
+  unscored: 'text-[var(--text-muted)]',
 };
 
 const scoreLabelClasses: Record<string, string> = {
@@ -49,6 +50,7 @@ const scoreLabelClasses: Record<string, string> = {
   competent: 'bg-yellow-900',
   tourist: 'bg-orange-900',
   flawed: 'bg-red-900',
+  unscored: 'bg-gray-700',
 };
 
 export function PhotoCard({
@@ -57,8 +59,8 @@ export function PhotoCard({
   onImageClick,
   onCorrectionUpdate,
 }: PhotoCardProps) {
-  const score = photo.final_score ?? 0;
-  const scoreLevel = getScoreLevel(score);
+  const scored = isScored(photo);
+  const scoreLevel = getScoreLevel(photo.final_score);
 
   const [imageError, setImageError] = useState(false);
 
@@ -115,20 +117,22 @@ export function PhotoCard({
         {/* Score Row */}
         <div className="flex items-center justify-between mb-3">
           <div className={`text-4xl font-bold ${scoreColorClasses[scoreLevel]}`}>
-            {score.toFixed(1)}
+            {scored ? photo.final_score!.toFixed(1) : '—'}
           </div>
           <span
             className={`text-xs px-2 py-1 rounded uppercase ${scoreLabelClasses[scoreLevel]}`}
           >
-            {getScoreLabel(score)}
+            {getScoreLabel(photo.final_score)}
           </span>
         </div>
 
         {/* Metrics */}
-        <ScoreBreakdown
-          aesthetic={photo.aesthetic_score || 0}
-          technical={photo.technical_score || 0}
-        />
+        {scored && (
+          <ScoreBreakdown
+            aesthetic={photo.aesthetic_score || 0}
+            technical={photo.technical_score || 0}
+          />
+        )}
 
         {/* Description */}
         {photo.description && (

--- a/packages/webapp/src/hooks/useCorrections.ts
+++ b/packages/webapp/src/hooks/useCorrections.ts
@@ -56,9 +56,9 @@ export function useCorrections(): UseCorrectionsResult {
 
         // If this is a new correction and we have photo data, store original values
         if (!prev[imagePath] && photo) {
-          existing.original_score = photo.final_score;
-          existing.original_aesthetic = photo.aesthetic_score;
-          existing.original_technical = photo.technical_score;
+          existing.original_score = photo.final_score ?? undefined;
+          existing.original_aesthetic = photo.aesthetic_score ?? undefined;
+          existing.original_technical = photo.technical_score ?? undefined;
         }
 
         return {

--- a/packages/webapp/src/hooks/useFilters.ts
+++ b/packages/webapp/src/hooks/useFilters.ts
@@ -24,19 +24,41 @@ export function useFilters(photos: Photo[]): UseFiltersResult {
 
     switch (sortBy) {
       case 'score_desc':
-        sorted.sort((a, b) => b.final_score - a.final_score);
+        // Put unscored (null) photos at the end
+        sorted.sort((a, b) => {
+          if (a.final_score === null && b.final_score === null) return 0;
+          if (a.final_score === null) return 1;
+          if (b.final_score === null) return -1;
+          return b.final_score - a.final_score;
+        });
         break;
       case 'score_asc':
-        sorted.sort((a, b) => a.final_score - b.final_score);
+        // Put unscored (null) photos at the end
+        sorted.sort((a, b) => {
+          if (a.final_score === null && b.final_score === null) return 0;
+          if (a.final_score === null) return 1;
+          if (b.final_score === null) return -1;
+          return a.final_score - b.final_score;
+        });
         break;
       case 'name':
         sorted.sort((a, b) => a.image_path.localeCompare(b.image_path));
         break;
       case 'aesthetic':
-        sorted.sort((a, b) => b.aesthetic_score - a.aesthetic_score);
+        sorted.sort((a, b) => {
+          if (a.aesthetic_score === null && b.aesthetic_score === null) return 0;
+          if (a.aesthetic_score === null) return 1;
+          if (b.aesthetic_score === null) return -1;
+          return b.aesthetic_score - a.aesthetic_score;
+        });
         break;
       case 'technical':
-        sorted.sort((a, b) => b.technical_score - a.technical_score);
+        sorted.sort((a, b) => {
+          if (a.technical_score === null && b.technical_score === null) return 0;
+          if (a.technical_score === null) return 1;
+          if (b.technical_score === null) return -1;
+          return b.technical_score - a.technical_score;
+        });
         break;
     }
 
@@ -48,7 +70,13 @@ export function useFilters(photos: Photo[]): UseFiltersResult {
       return { count: 0, avg: 0, min: 0, max: 0 };
     }
 
-    const scores = photos.map((p) => p.final_score);
+    // Only include scored photos in stats
+    const scoredPhotos = photos.filter((p) => p.final_score !== null);
+    if (scoredPhotos.length === 0) {
+      return { count: photos.length, avg: 0, min: 0, max: 0 };
+    }
+
+    const scores = scoredPhotos.map((p) => p.final_score!);
     return {
       count: photos.length,
       avg: scores.reduce((a, b) => a + b, 0) / scores.length,

--- a/packages/webapp/src/types/photo.ts
+++ b/packages/webapp/src/types/photo.ts
@@ -3,9 +3,9 @@ export interface Photo {
   image_path: string;  // Storage path
   original_filename: string | null;  // Original filename when uploaded
   image_url: string | null;  // Signed URL for displaying the image
-  final_score: number;
-  aesthetic_score: number;
-  technical_score: number;
+  final_score: number | null;  // null means not yet scored
+  aesthetic_score: number | null;
+  technical_score: number | null;
   composition: number;
   subject_strength: number;
   visual_appeal: number;
@@ -56,9 +56,11 @@ export type ScoreLevel =
   | 'strong'
   | 'competent'
   | 'tourist'
-  | 'flawed';
+  | 'flawed'
+  | 'unscored';
 
-export function getScoreLevel(score: number): ScoreLevel {
+export function getScoreLevel(score: number | null): ScoreLevel {
+  if (score === null) return 'unscored';
   if (score >= 85) return 'excellent';
   if (score >= 70) return 'strong';
   if (score >= 50) return 'competent';
@@ -66,10 +68,15 @@ export function getScoreLevel(score: number): ScoreLevel {
   return 'flawed';
 }
 
-export function getScoreLabel(score: number): string {
+export function getScoreLabel(score: number | null): string {
+  if (score === null) return 'Not Scored';
   if (score >= 85) return 'Excellent';
   if (score >= 70) return 'Strong';
   if (score >= 50) return 'Competent';
   if (score >= 30) return 'Tourist';
   return 'Flawed';
+}
+
+export function isScored(photo: Photo): boolean {
+  return photo.final_score !== null;
 }

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,382 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "photo-scoring"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/functions/process-scoring-queue/index.ts
+++ b/supabase/functions/process-scoring-queue/index.ts
@@ -1,0 +1,265 @@
+// Supabase Edge Function: process-scoring-queue
+// This function processes photos from the scoring queue in the background.
+// It is triggered by pg_notify when new jobs are added to the queue,
+// or can be invoked directly via HTTP to process pending jobs.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+interface ScoringJob {
+  id: string;
+  user_id: string;
+  photo_id: string;
+  status: string;
+  priority: number;
+  created_at: string;
+  retry_count: number;
+}
+
+// Call the FastAPI internal endpoint to process the photo
+async function processPhotoViaApi(
+  photoId: string,
+  userId: string,
+  apiBaseUrl: string,
+  internalApiKey: string
+): Promise<{ success: boolean; error?: string; finalScore?: number }> {
+  try {
+    const response = await fetch(
+      `${apiBaseUrl}/api/photos/internal/process-queue?x-internal-key=${encodeURIComponent(internalApiKey)}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          photo_id: photoId,
+          user_id: userId,
+        }),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data.detail || `HTTP ${response.status}: ${response.statusText}`,
+      };
+    }
+
+    if (data.success) {
+      return { success: true, finalScore: data.final_score };
+    } else {
+      return { success: false, error: data.error || "Unknown error" };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+// Process a single job from the queue
+async function processJob(
+  supabase: ReturnType<typeof createClient>,
+  job: ScoringJob,
+  apiBaseUrl: string,
+  internalApiKey: string
+): Promise<{ success: boolean; error?: string }> {
+  console.log(`Processing job ${job.id} for photo ${job.photo_id}`);
+
+  // Process the photo via the FastAPI backend
+  const result = await processPhotoViaApi(
+    job.photo_id,
+    job.user_id,
+    apiBaseUrl,
+    internalApiKey
+  );
+
+  if (result.success) {
+    console.log(
+      `Job ${job.id} completed successfully, score: ${result.finalScore}`
+    );
+  } else {
+    console.error(`Job ${job.id} failed: ${result.error}`);
+  }
+
+  return result;
+}
+
+// Process all pending jobs in the queue
+async function processPendingJobs(
+  supabase: ReturnType<typeof createClient>,
+  apiBaseUrl: string,
+  internalApiKey: string,
+  limit: number = 10
+): Promise<{ processed: number; succeeded: number; failed: number }> {
+  // Get pending jobs ordered by priority and created_at
+  const { data: jobs, error } = await supabase
+    .from("scoring_queue")
+    .select("*")
+    .eq("status", "pending")
+    .order("priority", { ascending: false })
+    .order("created_at", { ascending: true })
+    .limit(limit);
+
+  if (error || !jobs || jobs.length === 0) {
+    console.log("No pending jobs found");
+    return { processed: 0, succeeded: 0, failed: 0 };
+  }
+
+  console.log(`Found ${jobs.length} pending jobs`);
+
+  let succeeded = 0;
+  let failed = 0;
+
+  for (const job of jobs) {
+    const result = await processJob(supabase, job, apiBaseUrl, internalApiKey);
+    if (result.success) {
+      succeeded++;
+    } else {
+      failed++;
+    }
+  }
+
+  return { processed: jobs.length, succeeded, failed };
+}
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    // Get environment variables
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    // API_BASE_URL should point to the FastAPI backend
+    // For production, this would be something like https://api.photo-scoring.example.com
+    // For local development, use http://localhost:8000 or the appropriate host
+    const apiBaseUrl = Deno.env.get("API_BASE_URL") || "http://localhost:8000";
+    // Internal API key for authenticating with the FastAPI backend
+    // If not set, defaults to the service role key
+    const internalApiKey =
+      Deno.env.get("INTERNAL_API_KEY") || supabaseServiceKey;
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      throw new Error("Missing required environment variables");
+    }
+
+    if (!internalApiKey) {
+      throw new Error("Missing internal API key");
+    }
+
+    // Create Supabase client with service role
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Parse request body for notification payload (from pg_notify trigger or webhook)
+    let notificationPayload: {
+      id?: string;
+      photo_id?: string;
+      user_id?: string;
+    } | null = null;
+
+    if (req.method === "POST") {
+      try {
+        const body = await req.json();
+        // Check if this is from a database webhook trigger
+        if (body.record) {
+          notificationPayload = body.record;
+        } else if (body.id || body.photo_id) {
+          notificationPayload = body;
+        }
+      } catch {
+        // Not JSON body, that's fine - process all pending jobs
+      }
+    }
+
+    // If we have a specific job from notification, process just that one
+    if (notificationPayload?.photo_id) {
+      console.log(
+        `Processing specific job for photo: ${notificationPayload.photo_id}`
+      );
+
+      const { data: job, error: jobError } = await supabase
+        .from("scoring_queue")
+        .select("*")
+        .eq("photo_id", notificationPayload.photo_id)
+        .eq("status", "pending")
+        .single();
+
+      if (job && !jobError) {
+        const result = await processJob(
+          supabase,
+          job,
+          apiBaseUrl,
+          internalApiKey
+        );
+        return new Response(
+          JSON.stringify({
+            message: result.success
+              ? "Job processed successfully"
+              : "Job failed",
+            job_id: job.id,
+            photo_id: job.photo_id,
+            success: result.success,
+            error: result.error,
+          }),
+          {
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+            status: result.success ? 200 : 500,
+          }
+        );
+      } else {
+        // Job not found or already processed
+        return new Response(
+          JSON.stringify({
+            message: "Job not found or already processed",
+            photo_id: notificationPayload.photo_id,
+          }),
+          {
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+            status: 404,
+          }
+        );
+      }
+    }
+
+    // Otherwise, process all pending jobs
+    console.log("Processing all pending jobs");
+    const results = await processPendingJobs(
+      supabase,
+      apiBaseUrl,
+      internalApiKey
+    );
+
+    return new Response(
+      JSON.stringify({
+        message: "Queue processing complete",
+        ...results,
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 200,
+      }
+    );
+  } catch (error) {
+    console.error("Error processing queue:", error);
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      }
+    );
+  }
+});

--- a/supabase/migrations/20250101000000_initial_schema.sql
+++ b/supabase/migrations/20250101000000_initial_schema.sql
@@ -1,0 +1,213 @@
+-- Migration: Create credits table for user credit balance tracking
+-- Run this in Supabase SQL Editor
+
+-- Credits table
+CREATE TABLE IF NOT EXISTS credits (
+    user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    balance INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Trigger to update updated_at on changes
+CREATE OR REPLACE FUNCTION update_credits_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER credits_updated_at
+    BEFORE UPDATE ON credits
+    FOR EACH ROW
+    EXECUTE FUNCTION update_credits_updated_at();
+
+-- Row-Level Security
+ALTER TABLE credits ENABLE ROW LEVEL SECURITY;
+
+-- Users can view their own credits
+CREATE POLICY "Users can view own credits" ON credits
+    FOR SELECT USING (auth.uid() = user_id);
+
+-- Users cannot directly modify credits (handled by service key)
+-- This prevents client-side balance manipulation
+CREATE POLICY "Service role can manage credits" ON credits
+    FOR ALL USING (auth.role() = 'service_role');
+
+-- Index for performance (primary key already indexed)
+COMMENT ON TABLE credits IS 'User credit balance for inference API calls';
+COMMENT ON COLUMN credits.balance IS 'Current credit balance (1 credit = 1 image inference)';
+-- Migration: Create transactions table for credit history tracking
+-- Run this in Supabase SQL Editor after 001_credits.sql
+
+-- Transactions table
+CREATE TABLE IF NOT EXISTS transactions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    amount INTEGER NOT NULL,  -- positive = purchase/refund, negative = usage
+    type TEXT NOT NULL CHECK (type IN ('purchase', 'inference', 'refund', 'trial')),
+    stripe_payment_id TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index for efficient user transaction queries
+CREATE INDEX idx_transactions_user ON transactions(user_id);
+CREATE INDEX idx_transactions_user_created ON transactions(user_id, created_at DESC);
+
+-- Row-Level Security
+ALTER TABLE transactions ENABLE ROW LEVEL SECURITY;
+
+-- Users can view their own transactions
+CREATE POLICY "Users can view own transactions" ON transactions
+    FOR SELECT USING (auth.uid() = user_id);
+
+-- Only service role can insert/update transactions (prevents client manipulation)
+CREATE POLICY "Service role can manage transactions" ON transactions
+    FOR ALL USING (auth.role() = 'service_role');
+
+-- Comments for documentation
+COMMENT ON TABLE transactions IS 'Credit transaction history for audit trail';
+COMMENT ON COLUMN transactions.amount IS 'Credit change: positive for purchases/refunds, negative for usage';
+COMMENT ON COLUMN transactions.type IS 'Transaction type: purchase (Stripe), inference (API usage), refund';
+COMMENT ON COLUMN transactions.stripe_payment_id IS 'Stripe payment/checkout session ID for purchase transactions';
+-- Migration: Create scored_photos table for storing photo scoring results
+-- Run this in Supabase SQL Editor after 002_transactions.sql
+
+-- Scored photos table
+CREATE TABLE IF NOT EXISTS scored_photos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    storage_path TEXT NOT NULL,
+    original_filename TEXT,
+
+    -- Scoring results
+    final_score NUMERIC,
+    aesthetic_score NUMERIC,
+    technical_score NUMERIC,
+
+    -- AI-generated content
+    description TEXT,
+    explanation TEXT,
+    improvements TEXT,
+
+    -- Metadata
+    scene_type TEXT,
+    lighting TEXT,
+    subject_position TEXT,
+    location_name TEXT,
+    location_country TEXT,
+
+    -- Detailed scores and features (JSON for flexibility)
+    features_json JSONB,
+    model_scores JSONB,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Ensure unique storage path per user
+    UNIQUE(user_id, storage_path)
+);
+
+-- Trigger to update updated_at on changes
+CREATE OR REPLACE FUNCTION update_scored_photos_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER scored_photos_updated_at
+    BEFORE UPDATE ON scored_photos
+    FOR EACH ROW
+    EXECUTE FUNCTION update_scored_photos_updated_at();
+
+-- Indexes for efficient queries
+CREATE INDEX idx_scored_photos_user ON scored_photos(user_id);
+CREATE INDEX idx_scored_photos_user_created ON scored_photos(user_id, created_at DESC);
+CREATE INDEX idx_scored_photos_user_score ON scored_photos(user_id, final_score DESC);
+
+-- Row-Level Security
+ALTER TABLE scored_photos ENABLE ROW LEVEL SECURITY;
+
+-- Users can view their own photos
+CREATE POLICY "Users can view own photos" ON scored_photos
+    FOR SELECT USING (auth.uid() = user_id);
+
+-- Users can delete their own photos
+CREATE POLICY "Users can delete own photos" ON scored_photos
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- Only service role can insert/update (prevents client manipulation)
+CREATE POLICY "Service role can manage scored_photos" ON scored_photos
+    FOR ALL USING (auth.role() = 'service_role');
+
+-- Comments for documentation
+COMMENT ON TABLE scored_photos IS 'Stores scored photo results for each user';
+COMMENT ON COLUMN scored_photos.storage_path IS 'Path in Supabase Storage (e.g., photos/user-id/image.jpg)';
+COMMENT ON COLUMN scored_photos.final_score IS 'Combined aesthetic + technical score (0-100)';
+COMMENT ON COLUMN scored_photos.features_json IS 'Detailed features extracted by vision models';
+COMMENT ON COLUMN scored_photos.model_scores IS 'Raw scores from each model (qwen, gpt4o, gemini)';
+-- Migration: 004_inference_cache
+-- Description: Add cache tables for inference results
+-- Created: 2025-01-01
+
+-- Table for caching inference attributes (aesthetic + technical analysis)
+CREATE TABLE IF NOT EXISTS inference_cache (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    image_hash VARCHAR(64) NOT NULL,  -- SHA256 hash
+    attributes JSONB NOT NULL,  -- Normalized attributes from AI
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Unique constraint: one result per user+image combination
+    UNIQUE(user_id, image_hash)
+);
+
+-- Table for caching metadata extraction results
+CREATE TABLE IF NOT EXISTS metadata_cache (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    image_hash VARCHAR(64) NOT NULL,
+    metadata JSONB NOT NULL,  -- description, location_name, location_country
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+
+    UNIQUE(user_id, image_hash)
+);
+
+-- Indexes for efficient lookups
+CREATE INDEX IF NOT EXISTS idx_inference_cache_user_hash
+    ON inference_cache(user_id, image_hash);
+CREATE INDEX IF NOT EXISTS idx_metadata_cache_user_hash
+    ON metadata_cache(user_id, image_hash);
+
+-- RLS policies
+ALTER TABLE inference_cache ENABLE ROW LEVEL SECURITY;
+ALTER TABLE metadata_cache ENABLE ROW LEVEL SECURITY;
+
+-- Users can only access their own cache entries
+CREATE POLICY "Users can view own inference cache"
+    ON inference_cache FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own inference cache"
+    ON inference_cache FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can view own metadata cache"
+    ON metadata_cache FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own metadata cache"
+    ON metadata_cache FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+-- Service role bypass for backend operations
+CREATE POLICY "Service role full access inference_cache"
+    ON inference_cache FOR ALL
+    USING (auth.jwt() ->> 'role' = 'service_role');
+
+CREATE POLICY "Service role full access metadata_cache"
+    ON metadata_cache FOR ALL
+    USING (auth.jwt() ->> 'role' = 'service_role');


### PR DESCRIPTION
## Summary
- Fixes #70 - Scoring process stops when user navigates away
- Implements server-side queue for background photo scoring
- Dashboard now shows "Not scored" instead of "0" for unscored photos
- Regenerate button now works on unscored photos (triggers full scoring)

## Changes

### Issue 1: Dashboard shows "0" for unscored photos
- Modified `photo.ts` to make scores nullable (`number | null`)
- Added `isScored()` helper function and 'unscored' score level
- Updated `PhotoCard.tsx` to show "—" with "Not scored" label
- Updated `Lightbox.tsx` with appropriate styling and messaging

### Issue 2: Server-side queue for background scoring
- Created `scoring_queue` table migration with pg_notify trigger
- Added `/score/queue` endpoint to enqueue photos for background scoring
- Added `/status` endpoint for polling queue status
- Created Supabase Edge Function `process-scoring-queue` as worker
- Added internal API endpoint for Edge Function authentication
- Updated `Upload.tsx` to use queue-based flow with polling
- Credits deducted at queue time, refunded if job fails

### Issue 3: Regenerate endpoint handles unscored photos
- Modified regenerate endpoint to run full scoring pipeline if no `model_scores` exist
- Changed button text to "Analyze Photo" for unscored photos

## Architecture

The new scoring flow:
1. User uploads photo → stored in Supabase Storage
2. User requests scoring → credit deducted, job added to queue
3. Edge Function picks up job → calls internal API endpoint
4. Photo scored → queue marked complete, photo updated
5. Frontend polls `/status` every 2 seconds until complete

## Test plan
- [ ] Upload multiple photos and navigate away - scoring should continue
- [ ] Check dashboard shows "—" for unscored photos with "Not scored" label
- [ ] Click "Analyze Photo" on unscored photo - should trigger scoring
- [ ] Verify credit is deducted when queued, refunded if scoring fails
- [ ] Verify polling shows correct status (Queued → Scoring → Done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)