### PR TITLE
Fix Vercel rewrites to properly proxy /api requests

### DIFF
--- a/packages/webapp/vercel.json
+++ b/packages/webapp/vercel.json
@@ -5,15 +5,15 @@
   "framework": "vite",
   "rewrites": [
     {
-      "source": "/api/:path*",
-      "destination": "${BACKEND_URL}/api/:path*"
+      "source": "/api/:path(.*)",
+      "destination": "${BACKEND_URL}/api/:path"
     },
     {
-      "source": "/photos/:path*",
-      "destination": "${BACKEND_URL}/photos/:path*"
+      "source": "/photos/:path(.*)",
+      "destination": "${BACKEND_URL}/photos/:path"
     },
     {
-      "source": "/((?!assets/).*)",
+      "source": "/:path((?!api|photos|assets).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
## Summary

Fixes the Vercel rewrites configuration that was preventing `/api/*` requests from being proxied to the backend.

## Problem

The catch-all rewrite for SPA routing was incorrectly matching `/api/*` paths:
```json
{
  "source": "/((?!assets/).*)",
  "destination": "/index.html"
}
```

This caused all API requests to return the SPA's `index.html` instead of being proxied to the Render backend.

## Solution

- Use more explicit path patterns for API and photos rewrites
- Exclude `/api` and `/photos` from the SPA catch-all pattern

## Test plan

Verified via curl that:
- [x] Direct API calls to Render work: `curl https://photo-score-api.onrender.com/api/triage/active`
- [x] Triage start endpoint works with file uploads
- [x] Triage completes successfully (tested with 2 photos)
- [ ] Vercel proxy correctly forwards to backend after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)