### PR TITLE
Fix Vercel rewrites by hardcoding backend URL

### DIFF
--- a/packages/webapp/vercel.json
+++ b/packages/webapp/vercel.json
@@ -6,11 +6,11 @@
   "rewrites": [
     {
       "source": "/api/:path(.*)",
-      "destination": "${BACKEND_URL}/api/:path"
+      "destination": "https://photo-score-api.onrender.com/api/:path"
     },
     {
       "source": "/photos/:path(.*)",
-      "destination": "${BACKEND_URL}/photos/:path"
+      "destination": "https://photo-score-api.onrender.com/photos/:path"
     },
     {
       "source": "/:path((?!api|photos|assets).*)",


### PR DESCRIPTION
## Summary

- Vercel `vercel.json` does not support environment variable interpolation in rewrite destinations
- The `${BACKEND_URL}` syntax was not being replaced, causing all `/api/*` requests to return `index.html` instead of proxying to the backend
- Hardcode the Render backend URL directly (it's not a secret)

## Root Cause

According to [Vercel community discussions](https://community.vercel.com/t/is-there-any-way-to-use-env-in-vercel-json/1146), `vercel.json` does not natively support environment variables. The recommended alternatives are:
1. Edge Middleware (overkill for simple proxy)
2. Next.js `next.config.js` (not applicable - we use Vite)
3. Hardcoding the URL (simplest solution)

## Test plan

- [ ] After merge, verify `curl https://photo-scoring-9yf8.vercel.app/api/health` returns JSON instead of HTML
- [ ] Test triage flow in production webapp

---
Generated with [Claude Code](https://claude.ai/code)