### PR TITLE
Add local inference fallback with Qwen2-VL support

### DIFF
--- a/configs/local.yaml
+++ b/configs/local.yaml
@@ -1,9 +1,9 @@
 version: "1.0"
 
 model:
-  name: "anthropic/claude-3.5-sonnet"
-  version: "20241022"
-  backend: "cloud"
+  name: "local/qwen2-vl-2b-instruct"
+  version: "1.0"
+  backend: "local"
 
 weights:
   aesthetic:

--- a/packages/desktop/sidecar/handlers/inference.py
+++ b/packages/desktop/sidecar/handlers/inference.py
@@ -34,6 +34,11 @@ from .auth import get_auth_token  # noqa: E402
 
 router = APIRouter()
 
+# Desktop cloud model identity — filter cache lookups to these values
+# to prevent local CLI scores or CLI cloud scores from leaking in.
+CLOUD_MODEL_NAME = "anthropic/claude-3.5-sonnet"
+CLOUD_MODEL_VERSION = "cloud-v1"
+
 
 class ScoreRequest(BaseModel):
     """Request to score an image."""
@@ -101,7 +106,11 @@ async def get_attributes(
     try:
         image_id = compute_image_id(file_path)
         cache = Cache()
-        attrs = cache.get_attributes(image_id)
+        attrs = cache.get_attributes(
+            image_id,
+            model_name=CLOUD_MODEL_NAME,
+            model_version=CLOUD_MODEL_VERSION,
+        )
 
         if attrs is None:
             return None
@@ -144,8 +153,12 @@ async def score_image(request: ScoreRequest):
         cached = False
         credits_remaining = None
 
-        # Check cache first
-        attrs = cache.get_attributes(image_id)
+        # Check cache first — only match desktop cloud scores
+        attrs = cache.get_attributes(
+            image_id,
+            model_name=CLOUD_MODEL_NAME,
+            model_version=CLOUD_MODEL_VERSION,
+        )
 
         # Variables for critique data
         critique_explanation = ""
@@ -167,8 +180,10 @@ async def score_image(request: ScoreRequest):
                     sharpness=cloud_attrs["sharpness"],
                     exposure_balance=cloud_attrs["exposure_balance"],
                     noise_level=cloud_attrs["noise_level"],
-                    model_name=cloud_attrs.get("model_name", "cloud"),
-                    model_version=cloud_attrs.get("model_version", "v1"),
+                    model_name=cloud_attrs.get("model_name", CLOUD_MODEL_NAME),
+                    model_version=cloud_attrs.get(
+                        "model_version", CLOUD_MODEL_VERSION
+                    ),
                 )
                 attrs.scored_at = datetime.now(timezone.utc)
                 cache.store_attributes(attrs)
@@ -268,7 +283,11 @@ async def rescore_image(request: ScoreRequest):
         image_id = compute_image_id(file_path)
         cache = Cache()
 
-        attrs = cache.get_attributes(image_id)
+        attrs = cache.get_attributes(
+            image_id,
+            model_name=CLOUD_MODEL_NAME,
+            model_version=CLOUD_MODEL_VERSION,
+        )
         if attrs is None:
             raise HTTPException(
                 status_code=404,
@@ -341,7 +360,11 @@ async def get_cached_scores(request: CachedScoreRequest):
         try:
             image_id = compute_image_id(file_path)
             cache = Cache()
-            attrs = cache.get_attributes(image_id)
+            attrs = cache.get_attributes(
+                image_id,
+                model_name=CLOUD_MODEL_NAME,
+                model_version=CLOUD_MODEL_VERSION,
+            )
 
             if attrs is None:
                 scores[image_path] = None

--- a/packages/desktop/sidecar/handlers/inference.py
+++ b/packages/desktop/sidecar/handlers/inference.py
@@ -181,9 +181,7 @@ async def score_image(request: ScoreRequest):
                     exposure_balance=cloud_attrs["exposure_balance"],
                     noise_level=cloud_attrs["noise_level"],
                     model_name=cloud_attrs.get("model_name", CLOUD_MODEL_NAME),
-                    model_version=cloud_attrs.get(
-                        "model_version", CLOUD_MODEL_VERSION
-                    ),
+                    model_version=cloud_attrs.get("model_version", CLOUD_MODEL_VERSION),
                 )
                 attrs.scored_at = datetime.now(timezone.utc)
                 cache.store_attributes(attrs)

--- a/packages/desktop/sidecar/handlers/sync.py
+++ b/packages/desktop/sidecar/handlers/sync.py
@@ -19,6 +19,10 @@ logger = logging.getLogger(__name__)
 
 PUSH_BATCH_SIZE = 500
 
+# Sync-eligible model identity — must match the cloud API (packages/api)
+SYNC_MODEL_NAME = "anthropic/claude-3.5-sonnet"
+SYNC_MODEL_VERSION = "cloud-v1"
+
 # Settings file for persisting sync cursor
 SETTINGS_DIR = Path.home() / ".photo_score"
 SETTINGS_FILE = SETTINGS_DIR / "settings.json"
@@ -78,7 +82,9 @@ def _save_settings(settings: dict) -> None:
 async def get_sync_status():
     """Get current sync status."""
     cache = Cache()
-    unsynced = cache.list_unsynced_attributes()
+    unsynced = cache.list_unsynced_attributes(
+        model_name=SYNC_MODEL_NAME, model_version=SYNC_MODEL_VERSION
+    )
     return SyncStatusResponse(
         is_syncing=_sync_state["is_syncing"],
         last_sync=_sync_state["last_sync"],
@@ -108,10 +114,15 @@ async def start_sync(request: SyncRequest):
         cursor_after_id = settings.get("sync_cursor_after_id")
 
         # --- PUSH PHASE ---
-        unsynced = cache.list_unsynced_attributes()
+        # Only sync desktop cloud rows (not local or CLI cloud rows)
+        unsynced = cache.list_unsynced_attributes(
+            model_name=SYNC_MODEL_NAME, model_version=SYNC_MODEL_VERSION
+        )
         if unsynced:
             image_ids = [a.image_id for a in unsynced]
-            metadata_map = cache.list_all_metadata_for(image_ids)
+            metadata_map = cache.list_all_metadata_for(
+                image_ids, model_name=SYNC_MODEL_NAME
+            )
 
             # Batch into groups of PUSH_BATCH_SIZE
             for i in range(0, len(unsynced), PUSH_BATCH_SIZE):
@@ -151,13 +162,13 @@ async def start_sync(request: SyncRequest):
 
                     # Mark synced ids (those not in conflicts)
                     conflict_ids = {c["image_id"] for c in result.get("conflicts", [])}
-                    synced_ids = [
-                        r["image_id"]
+                    synced_rows = [
+                        (r["image_id"], SYNC_MODEL_NAME, SYNC_MODEL_VERSION)
                         for r in records
                         if r["image_id"] not in conflict_ids
                     ]
-                    if synced_ids:
-                        cache.mark_synced(synced_ids)
+                    if synced_rows:
+                        cache.mark_synced(synced_rows)
 
                     # Handle conflicts: overwrite local with cloud version
                     for conflict in result.get("conflicts", []):
@@ -181,17 +192,37 @@ async def start_sync(request: SyncRequest):
                                 sharpness=cloud_attrs.get("sharpness", 0),
                                 exposure_balance=cloud_attrs.get("exposure_balance", 0),
                                 noise_level=cloud_attrs.get("noise_level", 0),
-                                model_name=cloud_attrs.get("model_name"),
-                                model_version=cloud_attrs.get("model_version"),
+                                model_name=cloud_attrs.get(
+                                    "model_name", SYNC_MODEL_NAME
+                                ),
+                                model_version=cloud_attrs.get(
+                                    "model_version", SYNC_MODEL_VERSION
+                                ),
                                 scored_at=scored_at,
                             )
                             cache.store_attributes(attrs)
 
                         cloud_meta = cloud_rec.get("metadata")
                         if cloud_meta:
-                            cache.store_metadata(cid, ImageMetadata(**cloud_meta))
+                            cache.store_metadata(
+                                cid,
+                                ImageMetadata(**cloud_meta),
+                                model_name=cloud_attrs.get(
+                                    "model_name", SYNC_MODEL_NAME
+                                ),
+                            )
 
-                        cache.mark_synced([cid])
+                        cache.mark_synced(
+                            [
+                                (
+                                    cid,
+                                    cloud_attrs.get("model_name", SYNC_MODEL_NAME),
+                                    cloud_attrs.get(
+                                        "model_version", SYNC_MODEL_VERSION
+                                    ),
+                                )
+                            ]
+                        )
 
                 except Exception as e:
                     logger.error(f"Push batch failed: {e}")
@@ -215,6 +246,8 @@ async def start_sync(request: SyncRequest):
             for record in records:
                 rid = record["image_id"]
                 rattrs = record.get("attributes", {})
+                r_model_name = rattrs.get("model_name", SYNC_MODEL_NAME)
+                r_model_version = rattrs.get("model_version", SYNC_MODEL_VERSION)
                 cloud_scored_at = None
                 if record.get("scored_at"):
                     try:
@@ -223,15 +256,11 @@ async def start_sync(request: SyncRequest):
                         pass
 
                 # Only overwrite local if cloud is newer (or no local)
-                local = cache.get_attributes(rid)
+                local = cache.get_attributes(
+                    rid, model_name=r_model_name, model_version=r_model_version
+                )
                 if local is not None and local.scored_at is not None:
                     if cloud_scored_at is None or cloud_scored_at <= local.scored_at:
-                        # Local is newer or equal — keep local.
-                        # Do NOT mark_synced: if the row is still
-                        # pending upload (push failed), it must remain
-                        # unsynced so the next push retries it.
-                        # Already-synced rows won't re-upload anyway
-                        # (scored_at <= synced_at).
                         continue
 
                 attrs = NormalizedAttributes(
@@ -242,16 +271,18 @@ async def start_sync(request: SyncRequest):
                     sharpness=rattrs.get("sharpness", 0),
                     exposure_balance=rattrs.get("exposure_balance", 0),
                     noise_level=rattrs.get("noise_level", 0),
-                    model_name=rattrs.get("model_name"),
-                    model_version=rattrs.get("model_version"),
+                    model_name=r_model_name,
+                    model_version=r_model_version,
                     scored_at=cloud_scored_at,
                 )
                 cache.store_attributes(attrs)
-                cache.mark_synced([rid])
+                cache.mark_synced([(rid, r_model_name, r_model_version)])
 
                 rmeta = record.get("metadata")
                 if rmeta:
-                    cache.store_metadata(rid, ImageMetadata(**rmeta))
+                    cache.store_metadata(
+                        rid, ImageMetadata(**rmeta), model_name=r_model_name
+                    )
 
             # Advance cursor from response (always present when
             # records are returned)
@@ -271,7 +302,11 @@ async def start_sync(request: SyncRequest):
         _save_settings(settings)
 
         _sync_state["last_sync"] = datetime.now(timezone.utc).isoformat()
-        _sync_state["pending_count"] = len(cache.list_unsynced_attributes())
+        _sync_state["pending_count"] = len(
+            cache.list_unsynced_attributes(
+                model_name=SYNC_MODEL_NAME, model_version=SYNC_MODEL_VERSION
+            )
+        )
 
         return SyncResponse(
             status="completed" if not errors else "partial",

--- a/packages/desktop/sidecar/tests/test_sync.py
+++ b/packages/desktop/sidecar/tests/test_sync.py
@@ -11,6 +11,10 @@ import pytest
 from photo_score.storage.cache import Cache
 from photo_score.storage.models import ImageMetadata, NormalizedAttributes
 
+# Must match handlers/sync.py SYNC_MODEL_NAME / SYNC_MODEL_VERSION
+SYNC_MODEL_NAME = "anthropic/claude-3.5-sonnet"
+SYNC_MODEL_VERSION = "cloud-v1"
+
 
 @pytest.fixture
 def temp_cache():
@@ -29,7 +33,7 @@ def temp_settings(tmp_path):
 
 
 def _make_attrs(image_id, scored_at=None, composition=0.5):
-    """Helper to create NormalizedAttributes."""
+    """Helper to create NormalizedAttributes with sync-eligible identity."""
     return NormalizedAttributes(
         image_id=image_id,
         composition=composition,
@@ -38,6 +42,8 @@ def _make_attrs(image_id, scored_at=None, composition=0.5):
         sharpness=0.5,
         exposure_balance=0.5,
         noise_level=0.5,
+        model_name=SYNC_MODEL_NAME,
+        model_version=SYNC_MODEL_VERSION,
         scored_at=scored_at,
     )
 
@@ -123,6 +129,7 @@ class TestSyncOrchestration:
         temp_cache.store_metadata(
             "img_meta",
             ImageMetadata(description="A sunset", location_name="Beach"),
+            model_name=SYNC_MODEL_NAME,
         )
 
         settings_file = tmp_path / "settings.json"
@@ -491,7 +498,7 @@ class TestSyncOrchestration:
         local_time = datetime.now(timezone.utc)
         attrs = _make_attrs("keep_local", scored_at=local_time, composition=0.9)
         temp_cache.store_attributes(attrs)
-        temp_cache.mark_synced(["keep_local"])
+        temp_cache.mark_synced([("keep_local", SYNC_MODEL_NAME, SYNC_MODEL_VERSION)])
 
         settings_file = tmp_path / "settings.json"
         settings_file.write_text("{}")

--- a/photo_score/cli.py
+++ b/photo_score/cli.py
@@ -380,8 +380,10 @@ def rescore(
             result.final_score,
         )
 
-        # Get cached metadata if available
-        cached_metadata = cache.get_metadata(image.image_id)
+        # Get cached metadata from the same model that produced the attributes
+        cached_metadata = cache.get_metadata(
+            image.image_id, model_name=cached_attrs.model_name
+        )
         if cached_metadata is not None:
             result.metadata = cached_metadata
 

--- a/photo_score/cli.py
+++ b/photo_score/cli.py
@@ -8,7 +8,8 @@ from typing import Annotated, Optional
 import typer
 
 from photo_score.config.loader import get_default_config, load_config
-from photo_score.inference.client import OpenRouterClient, OpenRouterError
+from photo_score.inference.errors import InferenceError
+from photo_score.inference.factory import create_inference_client
 from photo_score.ingestion.discover import DEFAULT_EXTENSIONS, discover_images
 from photo_score.ingestion.metadata import extract_exif
 from photo_score.output.csv_writer import write_csv
@@ -69,6 +70,14 @@ def run(
             resolve_path=True,
         ),
     ] = None,
+    backend: Annotated[
+        Optional[str],
+        typer.Option(
+            "--backend",
+            "-b",
+            help="Inference backend: 'cloud', 'local', or 'auto'.",
+        ),
+    ] = None,
     overwrite: Annotated[
         bool,
         typer.Option(
@@ -112,6 +121,9 @@ def run(
         logger.info("Using default configuration")
         config = get_default_config()
 
+    # Determine backend: CLI flag overrides config
+    effective_backend = backend or config.model.backend
+
     # Parse extensions
     ext_set = None
     if extensions:
@@ -142,11 +154,25 @@ def run(
     cache_misses = 0
 
     try:
-        with OpenRouterClient(model_name=config.model.name) as client:
+        client = create_inference_client(
+            backend=effective_backend,
+            model_name=config.model.name,
+            model_version=config.model.version,
+        )
+
+        typer.echo(
+            f"Using {effective_backend} backend: {client.model_name} ({client.model_version})"
+        )
+
+        with client:
             with typer.progressbar(images, label="Processing images") as progress:
                 for image in progress:
-                    # Check cache for attributes
-                    cached_attrs = cache.get_attributes(image.image_id)
+                    # Check cache using client's model identity
+                    cached_attrs = cache.get_attributes(
+                        image.image_id,
+                        model_name=client.model_name,
+                        model_version=client.model_version,
+                    )
 
                     if cached_attrs is not None:
                         cache_hits += 1
@@ -166,12 +192,14 @@ def run(
                             # Stamp scored_at and cache result
                             attrs.scored_at = datetime.now(timezone.utc)
                             cache.store_attributes(attrs)
-                        except OpenRouterError as e:
+                        except InferenceError as e:
                             logger.warning(f"Failed to analyze {image.filename}: {e}")
                             continue
 
-                    # Get or extract metadata
-                    cached_metadata = cache.get_metadata(image.image_id)
+                    # Get or extract metadata (keyed by client model identity)
+                    cached_metadata = cache.get_metadata(
+                        image.image_id, model_name=client.model_name
+                    )
                     if cached_metadata is not None:
                         metadata = cached_metadata
                     else:
@@ -184,7 +212,7 @@ def run(
                             description = vision_meta.description
                             location_name = vision_meta.location_name
                             location_country = vision_meta.location_country
-                        except OpenRouterError as e:
+                        except InferenceError as e:
                             logger.warning(
                                 f"Failed to get metadata for {image.filename}: {e}"
                             )
@@ -202,8 +230,10 @@ def run(
                             location_country=location_country,
                         )
 
-                        # Cache metadata
-                        cache.store_metadata(image.image_id, metadata)
+                        # Cache metadata with client model identity
+                        cache.store_metadata(
+                            image.image_id, metadata, model_name=client.model_name
+                        )
 
                     # Compute scores
                     result = reducer.compute_scores(
@@ -224,7 +254,7 @@ def run(
 
                     results.append(result)
 
-    except OpenRouterError as e:
+    except InferenceError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
@@ -324,7 +354,7 @@ def rescore(
     reducer = ScoringReducer(config)
     explainer = ExplanationGenerator(config)
 
-    # Process images from cache only
+    # Process images from cache only (no model filter — use latest available)
     results: list[ScoringResult] = []
     missing = 0
 
@@ -845,6 +875,69 @@ def triage(
     else:
         typer.echo("No photos selected.")
         raise typer.Exit(code=0)
+
+
+@app.command()
+def hardware() -> None:
+    """Detect hardware capabilities for local inference."""
+    try:
+        from photo_score.inference.local.hardware import detect_capabilities
+    except ImportError:
+        typer.echo("Local inference extras not installed.")
+        typer.echo("Install with: uv pip install 'photo-score[local]'")
+        raise typer.Exit(code=1)
+
+    caps = detect_capabilities()
+    typer.echo("Hardware Detection:")
+    typer.echo(f"  CUDA available: {caps.has_cuda}")
+    typer.echo(f"  MPS available:  {caps.has_mps}")
+    if caps.cuda_vram_gb is not None:
+        typer.echo(f"  CUDA VRAM:      {caps.cuda_vram_gb:.1f} GB")
+    typer.echo(f"  Selected device: {caps.device}")
+    typer.echo(f"  Can run local:   {caps.can_run_local}")
+
+
+@app.command("models")
+def models_cmd(
+    action: Annotated[
+        str,
+        typer.Argument(help="Action: 'list', 'download', or 'delete'."),
+    ],
+) -> None:
+    """Manage local inference models."""
+    try:
+        from photo_score.inference.local.model_manager import ModelManager
+    except ImportError:
+        typer.echo("Local inference extras not installed.")
+        typer.echo("Install with: uv pip install 'photo-score[local]'")
+        raise typer.Exit(code=1)
+
+    manager = ModelManager()
+
+    if action == "list":
+        models_list = manager.list_models()
+        if not models_list:
+            typer.echo("No local models downloaded.")
+            typer.echo("Run: photo-score models download")
+        else:
+            for m in models_list:
+                typer.echo(f"  {m.model_id} ({m.size_gb:.1f} GB) - {m.path}")
+    elif action == "download":
+        if manager.is_model_available():
+            typer.echo("Model already downloaded.")
+            return
+        typer.echo("Downloading model (this may take a few minutes)...")
+        path = manager.download_model()
+        typer.echo(f"Model downloaded to: {path}")
+    elif action == "delete":
+        if not manager.is_model_available():
+            typer.echo("No model to delete.")
+            return
+        manager.delete_model()
+        typer.echo("Model deleted.")
+    else:
+        typer.echo(f"Unknown action: {action}. Use 'list', 'download', or 'delete'.")
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/photo_score/cli.py
+++ b/photo_score/cli.py
@@ -354,12 +354,16 @@ def rescore(
     reducer = ScoringReducer(config)
     explainer = ExplanationGenerator(config)
 
-    # Process images from cache only (no model filter — use latest available)
+    # Process images from cache filtered by config model identity
+    model_name = config.model.name
+    model_version = config.model.version
     results: list[ScoringResult] = []
     missing = 0
 
     for image in images:
-        cached_attrs = cache.get_attributes(image.image_id)
+        cached_attrs = cache.get_attributes(
+            image.image_id, model_name=model_name, model_version=model_version
+        )
 
         if cached_attrs is None:
             missing += 1

--- a/photo_score/config/schema.py
+++ b/photo_score/config/schema.py
@@ -8,6 +8,7 @@ class ModelConfig(BaseModel):
 
     name: str = Field(default="anthropic/claude-3.5-sonnet")
     version: str = Field(default="20241022")
+    backend: str = Field(default="cloud")
 
 
 class AestheticWeights(BaseModel):

--- a/photo_score/inference/__init__.py
+++ b/photo_score/inference/__init__.py
@@ -1,13 +1,28 @@
-"""Vision model inference via OpenRouter.
-
-This module provides the API client for making vision model calls
-to OpenRouter for photo analysis.
+"""Vision model inference via OpenRouter and local models.
 
 Main exports:
 - OpenRouterClient: HTTP client for vision model API calls
 - OpenRouterError: Exception for API errors
+- InferenceClient: Protocol for inference backends
+- InferenceError: Base exception for all inference errors
+- create_inference_client: Factory function
 """
 
+from photo_score.inference.base import InferenceClient
 from photo_score.inference.client import OpenRouterClient, OpenRouterError
+from photo_score.inference.errors import (
+    CloudInferenceError,
+    InferenceError,
+    LocalInferenceError,
+)
+from photo_score.inference.factory import create_inference_client
 
-__all__ = ["OpenRouterClient", "OpenRouterError"]
+__all__ = [
+    "OpenRouterClient",
+    "OpenRouterError",
+    "InferenceClient",
+    "InferenceError",
+    "CloudInferenceError",
+    "LocalInferenceError",
+    "create_inference_client",
+]

--- a/photo_score/inference/base.py
+++ b/photo_score/inference/base.py
@@ -1,0 +1,27 @@
+"""Inference client protocol."""
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from photo_score.inference.schemas import MetadataResponse
+from photo_score.storage.models import NormalizedAttributes
+
+
+@runtime_checkable
+class InferenceClient(Protocol):
+    """Protocol for inference backends (cloud or local)."""
+
+    model_name: str
+    model_version: str
+
+    def analyze_image(
+        self, image_id: str, image_path: Path, model_version: str
+    ) -> NormalizedAttributes: ...
+
+    def analyze_metadata(self, image_path: Path) -> MetadataResponse: ...
+
+    def close(self) -> None: ...
+
+    def __enter__(self) -> "InferenceClient": ...
+
+    def __exit__(self, *args) -> None: ...

--- a/photo_score/inference/client.py
+++ b/photo_score/inference/client.py
@@ -1,26 +1,19 @@
 """OpenRouter API client for vision model inference."""
 
-import base64
-import json
 import logging
 import os
-import re
 import time
-from io import BytesIO
 from pathlib import Path
 
 import httpx
-from PIL import Image, ImageOps
 from pydantic import ValidationError
 
-# Register HEIC/HEIF support
-try:
-    import pillow_heif
-
-    pillow_heif.register_heif_opener()
-except ImportError:
-    pass  # pillow-heif not installed, HEIC files won't work
-
+from photo_score.inference.errors import CloudInferenceError
+from photo_score.inference.image_utils import (
+    load_and_preprocess_image,
+    encode_image_base64,
+)
+from photo_score.inference.parsing import extract_json_from_response
 from photo_score.inference.prompts import (
     AESTHETIC_PROMPT,
     TECHNICAL_PROMPT,
@@ -36,7 +29,6 @@ from photo_score.storage.models import NormalizedAttributes
 logger = logging.getLogger(__name__)
 
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
-MAX_IMAGE_DIMENSION = 2048
 
 # Model tiers for different tasks
 # Scoring requires nuanced judgment - use higher quality model
@@ -47,7 +39,7 @@ MODEL_METADATA = (
 )
 
 
-class OpenRouterError(Exception):
+class OpenRouterError(CloudInferenceError):
     """Error from OpenRouter API."""
 
     pass
@@ -60,20 +52,23 @@ class OpenRouterClient:
         self,
         api_key: str | None = None,
         model_name: str = "anthropic/claude-3.5-sonnet",
+        model_version: str = "unknown",
     ):
         """Initialize client.
 
         Args:
             api_key: OpenRouter API key. Defaults to OPENROUTER_API_KEY env var.
             model_name: Model identifier for OpenRouter.
+            model_version: Version string for this model configuration.
         """
         self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
         if not self.api_key:
-            raise ValueError(
+            raise CloudInferenceError(
                 "OpenRouter API key required. Set OPENROUTER_API_KEY environment variable."
             )
 
         self.model_name = model_name
+        self.model_version = model_version
         self.client = httpx.Client(timeout=120.0)
 
     def _load_and_encode_image(self, image_path: Path) -> tuple[str, str]:
@@ -82,26 +77,8 @@ class OpenRouterClient:
         Returns:
             Tuple of (base64_data, media_type)
         """
-        with Image.open(image_path) as img:
-            # Apply EXIF orientation (fixes rotated images from phones)
-            img = ImageOps.exif_transpose(img)
-
-            # Convert to RGB if needed (handles RGBA, P mode, etc.)
-            if img.mode not in ("RGB", "L"):
-                img = img.convert("RGB")
-
-            # Resize if too large
-            if max(img.size) > MAX_IMAGE_DIMENSION:
-                ratio = MAX_IMAGE_DIMENSION / max(img.size)
-                new_size = (int(img.size[0] * ratio), int(img.size[1] * ratio))
-                img = img.resize(new_size, Image.Resampling.LANCZOS)
-
-            # Encode to JPEG
-            buffer = BytesIO()
-            img.save(buffer, format="JPEG", quality=85)
-            base64_data = base64.b64encode(buffer.getvalue()).decode("utf-8")
-
-            return base64_data, "image/jpeg"
+        img = load_and_preprocess_image(image_path)
+        return encode_image_base64(img)
 
     def call_api(
         self,
@@ -191,40 +168,10 @@ class OpenRouterClient:
         result = response.json()
         content = result["choices"][0]["message"]["content"]
 
-        # Extract JSON from response (handle markdown code blocks and nested structures)
-        # First try to extract from markdown code block
-        code_block_match = re.search(
-            r"```(?:json)?\s*(\{.*?\})\s*```", content, re.DOTALL
-        )
-        if code_block_match:
-            try:
-                return json.loads(code_block_match.group(1))
-            except json.JSONDecodeError:
-                pass
-
-        # Try to find JSON by matching balanced braces
-        # Find the first { and extract everything to the matching }
-        start_idx = content.find("{")
-        if start_idx == -1:
-            raise OpenRouterError(f"No JSON found in response: {content}")
-
-        # Count braces to find matching closing brace
-        depth = 0
-        end_idx = start_idx
-        for i, char in enumerate(content[start_idx:], start_idx):
-            if char == "{":
-                depth += 1
-            elif char == "}":
-                depth -= 1
-                if depth == 0:
-                    end_idx = i + 1
-                    break
-
-        json_str = content[start_idx:end_idx]
         try:
-            return json.loads(json_str)
-        except json.JSONDecodeError as e:
-            raise OpenRouterError(f"Invalid JSON in response: {e}\nContent: {content}")
+            return extract_json_from_response(content)
+        except ValueError as e:
+            raise OpenRouterError(str(e))
 
     def analyze_aesthetic(self, image_path: Path) -> AestheticResponse:
         """Analyze aesthetic qualities of an image."""

--- a/photo_score/inference/errors.py
+++ b/photo_score/inference/errors.py
@@ -1,0 +1,31 @@
+"""Error hierarchy for inference backends."""
+
+
+class InferenceError(Exception):
+    """Base error for all inference operations."""
+
+    pass
+
+
+class CloudInferenceError(InferenceError):
+    """Error from cloud inference (OpenRouter, etc)."""
+
+    pass
+
+
+class LocalInferenceError(InferenceError):
+    """Error from local inference."""
+
+    pass
+
+
+class ModelNotAvailableError(LocalInferenceError):
+    """The requested local model is not downloaded."""
+
+    pass
+
+
+class HardwareInsufficientError(LocalInferenceError):
+    """The local hardware cannot run the requested model."""
+
+    pass

--- a/photo_score/inference/factory.py
+++ b/photo_score/inference/factory.py
@@ -1,0 +1,112 @@
+"""Factory for creating inference clients."""
+
+from photo_score.inference.base import InferenceClient
+from photo_score.inference.errors import (
+    CloudInferenceError,
+    HardwareInsufficientError,
+    LocalInferenceError,
+    ModelNotAvailableError,
+)
+
+
+def create_inference_client(
+    backend: str = "cloud",
+    model_name: str = "anthropic/claude-3.5-sonnet",
+    model_version: str = "unknown",
+    api_key: str | None = None,
+) -> InferenceClient:
+    """Create an inference client for the specified backend.
+
+    Args:
+        backend: "cloud", "local", or "auto".
+        model_name: Model identifier (used for cloud backend).
+        model_version: Version string.
+        api_key: API key (used for cloud backend).
+
+    Returns:
+        An InferenceClient instance.
+    """
+    if backend == "cloud":
+        from photo_score.inference.client import OpenRouterClient
+
+        return OpenRouterClient(
+            api_key=api_key,
+            model_name=model_name,
+            model_version=model_version,
+        )
+    elif backend == "local":
+        return _create_local_client()
+    elif backend == "auto":
+        return _create_auto_client(
+            model_name=model_name,
+            model_version=model_version,
+            api_key=api_key,
+        )
+    else:
+        raise ValueError(
+            f"Unknown backend: {backend!r}. Use 'cloud', 'local', or 'auto'."
+        )
+
+
+def _create_local_client() -> InferenceClient:
+    """Create a local inference client, checking all prerequisites."""
+    try:
+        from photo_score.inference.local.qwen_client import QwenLocalClient
+    except ImportError:
+        raise LocalInferenceError(
+            "Local inference extras not installed.\n"
+            "Install with: uv pip install 'photo-score[local]'"
+        )
+
+    from photo_score.inference.local.hardware import detect_capabilities
+    from photo_score.inference.local.model_manager import ModelManager
+
+    caps = detect_capabilities()
+    if not caps.can_run_local:
+        raise HardwareInsufficientError(
+            f"Insufficient hardware for local inference.\n"
+            f"Detected: device={caps.device}, "
+            f"CUDA VRAM={caps.cuda_vram_gb or 'N/A'}GB\n"
+            f"Requires: Apple Silicon (MPS) or CUDA GPU with >=4GB VRAM."
+        )
+
+    manager = ModelManager()
+    if not manager.is_model_available():
+        raise ModelNotAvailableError(
+            "Local model not downloaded.\nRun: photo-score models download"
+        )
+
+    model_path = manager.get_model_path()
+    return QwenLocalClient(
+        model_path=model_path,
+        device=caps.device,
+        quantize=(caps.device == "cuda"),
+    )
+
+
+def _create_auto_client(
+    model_name: str,
+    model_version: str,
+    api_key: str | None,
+) -> InferenceClient:
+    """Try local first, fall back to cloud."""
+    try:
+        return _create_local_client()
+    except (LocalInferenceError, ImportError):
+        pass
+
+    # Fall back to cloud
+    try:
+        from photo_score.inference.client import OpenRouterClient
+
+        return OpenRouterClient(
+            api_key=api_key,
+            model_name=model_name,
+            model_version=model_version,
+        )
+    except CloudInferenceError:
+        raise CloudInferenceError(
+            "No inference backend available.\n"
+            "Either install local extras (`uv pip install 'photo-score[local]'`) "
+            "or set OPENROUTER_API_KEY for cloud inference."
+        )

--- a/photo_score/inference/image_utils.py
+++ b/photo_score/inference/image_utils.py
@@ -1,0 +1,47 @@
+"""Shared image preprocessing utilities."""
+
+import base64
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image, ImageOps
+
+MAX_IMAGE_DIMENSION = 2048
+
+# Register HEIC/HEIF support
+try:
+    import pillow_heif
+
+    pillow_heif.register_heif_opener()
+except ImportError:
+    pass
+
+
+def load_and_preprocess_image(
+    image_path: Path, max_dimension: int = MAX_IMAGE_DIMENSION
+) -> Image.Image:
+    """Load image, apply EXIF transpose, convert to RGB, resize if needed."""
+    img = Image.open(image_path)
+    img = ImageOps.exif_transpose(img)
+
+    if img.mode not in ("RGB", "L"):
+        img = img.convert("RGB")
+
+    if max(img.size) > max_dimension:
+        ratio = max_dimension / max(img.size)
+        new_size = (int(img.size[0] * ratio), int(img.size[1] * ratio))
+        img = img.resize(new_size, Image.Resampling.LANCZOS)
+
+    return img
+
+
+def encode_image_base64(image: Image.Image, quality: int = 85) -> tuple[str, str]:
+    """Encode PIL Image to base64 JPEG.
+
+    Returns:
+        Tuple of (base64_data, media_type).
+    """
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG", quality=quality)
+    base64_data = base64.b64encode(buffer.getvalue()).decode("utf-8")
+    return base64_data, "image/jpeg"

--- a/photo_score/inference/local/__init__.py
+++ b/photo_score/inference/local/__init__.py
@@ -1,0 +1,1 @@
+"""Local inference using on-device vision models."""

--- a/photo_score/inference/local/calibration.py
+++ b/photo_score/inference/local/calibration.py
@@ -1,0 +1,68 @@
+"""Score calibration for local inference models.
+
+Qwen2-VL-2B scores differently from Claude 3.5 Sonnet. This module
+applies per-attribute affine transforms to align local scores closer
+to the cloud baseline.
+"""
+
+from dataclasses import dataclass
+
+from photo_score.storage.models import NormalizedAttributes
+
+
+@dataclass
+class CalibrationMap:
+    """Per-attribute affine mapping: calibrated = clamp(slope * raw + intercept, 0, 1)."""
+
+    composition: tuple[float, float]
+    subject_strength: tuple[float, float]
+    visual_appeal: tuple[float, float]
+    sharpness: tuple[float, float]
+    exposure_balance: tuple[float, float]
+    noise_level: tuple[float, float]
+
+
+# Initial conservative calibration.
+# Qwen2-VL-2B is generally less critical than Claude 3.5 Sonnet.
+# These scale down slightly. Will be refined with real comparison data.
+DEFAULT_CALIBRATION = CalibrationMap(
+    composition=(0.85, 0.0),
+    subject_strength=(0.85, 0.0),
+    visual_appeal=(0.80, 0.0),
+    sharpness=(0.90, 0.0),
+    exposure_balance=(0.90, 0.0),
+    noise_level=(0.95, 0.0),
+)
+
+
+def _clamp(value: float) -> float:
+    """Clamp value to [0, 1]."""
+    return max(0.0, min(1.0, value))
+
+
+def apply_calibration(
+    attrs: NormalizedAttributes,
+    cal: CalibrationMap,
+) -> NormalizedAttributes:
+    """Apply per-attribute affine transform, clamp to [0, 1].
+
+    Returns a new NormalizedAttributes with calibrated values.
+    """
+    return NormalizedAttributes(
+        image_id=attrs.image_id,
+        composition=_clamp(cal.composition[0] * attrs.composition + cal.composition[1]),
+        subject_strength=_clamp(
+            cal.subject_strength[0] * attrs.subject_strength + cal.subject_strength[1]
+        ),
+        visual_appeal=_clamp(
+            cal.visual_appeal[0] * attrs.visual_appeal + cal.visual_appeal[1]
+        ),
+        sharpness=_clamp(cal.sharpness[0] * attrs.sharpness + cal.sharpness[1]),
+        exposure_balance=_clamp(
+            cal.exposure_balance[0] * attrs.exposure_balance + cal.exposure_balance[1]
+        ),
+        noise_level=_clamp(cal.noise_level[0] * attrs.noise_level + cal.noise_level[1]),
+        model_name=attrs.model_name,
+        model_version=attrs.model_version,
+        scored_at=attrs.scored_at,
+    )

--- a/photo_score/inference/local/hardware.py
+++ b/photo_score/inference/local/hardware.py
@@ -1,0 +1,60 @@
+"""Hardware capability detection for local inference."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HardwareCapabilities:
+    """Detected hardware capabilities."""
+
+    has_cuda: bool
+    has_mps: bool
+    cuda_vram_gb: float | None
+    device: str  # "cuda", "mps", or "cpu"
+    can_run_local: bool
+
+
+# Qwen2-VL-2B minimum VRAM requirements
+MIN_CUDA_VRAM_GB = 4.0  # 4-bit quantization
+
+
+def detect_capabilities() -> HardwareCapabilities:
+    """Detect hardware capabilities for local inference.
+
+    Checks for CUDA and MPS (Apple Silicon) support.
+    Qwen2-VL-2B needs ~4GB VRAM (4-bit) or ~4GB unified memory (fp16 on MPS).
+    """
+    has_cuda = False
+    has_mps = False
+    cuda_vram_gb = None
+
+    try:
+        import torch
+
+        has_cuda = torch.cuda.is_available()
+        if has_cuda:
+            props = torch.cuda.get_device_properties(0)
+            cuda_vram_gb = props.total_memory / (1024**3)
+
+        has_mps = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+    except ImportError:
+        pass
+
+    # Determine best device
+    if has_cuda and cuda_vram_gb is not None and cuda_vram_gb >= MIN_CUDA_VRAM_GB:
+        device = "cuda"
+        can_run = True
+    elif has_mps:
+        device = "mps"
+        can_run = True
+    else:
+        device = "cpu"
+        can_run = False
+
+    return HardwareCapabilities(
+        has_cuda=has_cuda,
+        has_mps=has_mps,
+        cuda_vram_gb=cuda_vram_gb,
+        device=device,
+        can_run_local=can_run,
+    )

--- a/photo_score/inference/local/model_manager.py
+++ b/photo_score/inference/local/model_manager.py
@@ -1,0 +1,98 @@
+"""Model download and management for local inference."""
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_MODEL_DIR = Path.home() / ".photo_score" / "models"
+LOCAL_MODEL_ID = "Qwen/Qwen2-VL-2B-Instruct"
+
+
+@dataclass
+class LocalModelInfo:
+    """Info about a downloaded local model."""
+
+    model_id: str
+    path: Path
+    size_gb: float
+
+
+class ModelManager:
+    """Manage local model downloads."""
+
+    def __init__(self, model_dir: Path | None = None):
+        self.model_dir = model_dir or DEFAULT_MODEL_DIR
+        self.model_id = LOCAL_MODEL_ID
+
+    def _model_path(self, model_id: str | None = None) -> Path:
+        """Get the expected path for a model."""
+        mid = model_id or self.model_id
+        # Convert "Qwen/Qwen2-VL-2B-Instruct" -> "Qwen--Qwen2-VL-2B-Instruct"
+        safe_name = mid.replace("/", "--")
+        return self.model_dir / safe_name
+
+    def is_model_available(self, model_id: str | None = None) -> bool:
+        """Check if a model is downloaded."""
+        path = self._model_path(model_id)
+        # Check for config.json as a marker that download completed
+        return (path / "config.json").exists()
+
+    def get_model_path(self, model_id: str | None = None) -> Path | None:
+        """Get the path to a downloaded model, or None if not available."""
+        path = self._model_path(model_id)
+        if self.is_model_available(model_id):
+            return path
+        return None
+
+    def download_model(
+        self,
+        model_id: str | None = None,
+        progress_callback=None,
+    ) -> Path:
+        """Download a model from Hugging Face Hub.
+
+        Returns:
+            Path to the downloaded model directory.
+        """
+        from huggingface_hub import snapshot_download
+
+        mid = model_id or self.model_id
+        path = self._model_path(mid)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        snapshot_download(
+            repo_id=mid,
+            local_dir=str(path),
+        )
+
+        return path
+
+    def list_models(self) -> list[LocalModelInfo]:
+        """List all downloaded models."""
+        if not self.model_dir.exists():
+            return []
+
+        models = []
+        for entry in self.model_dir.iterdir():
+            if entry.is_dir() and (entry / "config.json").exists():
+                # Calculate size
+                total_size = sum(
+                    f.stat().st_size for f in entry.rglob("*") if f.is_file()
+                )
+                size_gb = total_size / (1024**3)
+                # Convert "Qwen--Qwen2-VL-2B-Instruct" back to "Qwen/Qwen2-VL-2B-Instruct"
+                model_id = entry.name.replace("--", "/")
+                models.append(
+                    LocalModelInfo(
+                        model_id=model_id,
+                        path=entry,
+                        size_gb=size_gb,
+                    )
+                )
+        return models
+
+    def delete_model(self, model_id: str | None = None) -> None:
+        """Delete a downloaded model."""
+        path = self._model_path(model_id)
+        if path.exists():
+            shutil.rmtree(path)

--- a/photo_score/inference/local/qwen_client.py
+++ b/photo_score/inference/local/qwen_client.py
@@ -1,0 +1,193 @@
+"""Local Qwen2-VL inference client."""
+
+import logging
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from photo_score.inference.errors import LocalInferenceError
+from photo_score.inference.parsing import extract_json_from_response
+from photo_score.inference.prompts import (
+    AESTHETIC_PROMPT,
+    TECHNICAL_PROMPT,
+    METADATA_PROMPT,
+)
+from photo_score.inference.schemas import (
+    AestheticResponse,
+    TechnicalResponse,
+    MetadataResponse,
+)
+from photo_score.inference.local.calibration import (
+    DEFAULT_CALIBRATION,
+    apply_calibration,
+)
+from photo_score.storage.models import NormalizedAttributes
+
+logger = logging.getLogger(__name__)
+
+
+class QwenLocalClient:
+    """Local inference client using Qwen2-VL-2B-Instruct."""
+
+    def __init__(
+        self,
+        model_path: Path,
+        device: str = "auto",
+        quantize: bool = False,
+    ):
+        self.model_name = "local/qwen2-vl-2b-instruct"
+        self.model_version = "1.0"
+        self._model_path = model_path
+        self._device = device
+        self._quantize = quantize
+        self._model = None
+        self._processor = None
+
+    def _ensure_loaded(self) -> None:
+        """Lazy-load model and processor."""
+        if self._model is not None:
+            return
+
+        import torch
+        from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
+
+        load_kwargs = {
+            "pretrained_model_name_or_path": str(self._model_path),
+            "torch_dtype": torch.float16,
+        }
+
+        if self._quantize:
+            from transformers import BitsAndBytesConfig
+
+            load_kwargs["quantization_config"] = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_compute_dtype=torch.float16,
+            )
+        elif self._device == "mps":
+            load_kwargs["device_map"] = "mps"
+        elif self._device == "cuda":
+            load_kwargs["device_map"] = "auto"
+
+        self._model = Qwen2VLForConditionalGeneration.from_pretrained(**load_kwargs)
+        self._processor = AutoProcessor.from_pretrained(str(self._model_path))
+
+        if self._device == "mps" and not self._quantize:
+            self._model = self._model.to("mps")
+
+        logger.info(f"Loaded Qwen2-VL-2B on {self._device}")
+
+    def _run_inference(self, image_path: Path, prompt: str) -> str:
+        """Run a single inference pass on an image with a prompt."""
+        import torch
+        from qwen_vl_utils import process_vision_info
+
+        self._ensure_loaded()
+
+        # Build the conversation message
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": str(image_path)},
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ]
+
+        text = self._processor.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        image_inputs, video_inputs = process_vision_info(messages)
+
+        inputs = self._processor(
+            text=[text],
+            images=image_inputs,
+            videos=video_inputs,
+            padding=True,
+            return_tensors="pt",
+        )
+        inputs = inputs.to(self._model.device)
+
+        with torch.no_grad():
+            generated_ids = self._model.generate(**inputs, max_new_tokens=256)
+
+        # Only decode the newly generated tokens
+        generated_ids_trimmed = [
+            out_ids[len(in_ids) :]
+            for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
+        ]
+        output = self._processor.batch_decode(
+            generated_ids_trimmed,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+
+        return output[0] if output else ""
+
+    def analyze_image(
+        self, image_id: str, image_path: Path, model_version: str
+    ) -> NormalizedAttributes:
+        """Run full analysis on an image."""
+        # Run aesthetic analysis
+        aesthetic_text = self._run_inference(image_path, AESTHETIC_PROMPT)
+        try:
+            aesthetic_data = extract_json_from_response(aesthetic_text)
+            aesthetic = AestheticResponse.model_validate(aesthetic_data)
+        except (ValueError, ValidationError) as e:
+            raise LocalInferenceError(f"Failed to parse aesthetic response: {e}")
+
+        # Run technical analysis
+        technical_text = self._run_inference(image_path, TECHNICAL_PROMPT)
+        try:
+            technical_data = extract_json_from_response(technical_text)
+            technical = TechnicalResponse.model_validate(technical_data)
+        except (ValueError, ValidationError) as e:
+            raise LocalInferenceError(f"Failed to parse technical response: {e}")
+
+        raw_attrs = NormalizedAttributes(
+            image_id=image_id,
+            composition=aesthetic.composition,
+            subject_strength=aesthetic.subject_strength,
+            visual_appeal=aesthetic.visual_appeal,
+            sharpness=technical.sharpness,
+            exposure_balance=technical.exposure_balance,
+            noise_level=technical.noise_level,
+            model_name=self.model_name,
+            model_version=self.model_version,
+        )
+
+        # Apply calibration to align with cloud scores
+        return apply_calibration(raw_attrs, DEFAULT_CALIBRATION)
+
+    def analyze_metadata(self, image_path: Path) -> MetadataResponse:
+        """Get description and location metadata for an image."""
+        text = self._run_inference(image_path, METADATA_PROMPT)
+        try:
+            data = extract_json_from_response(text)
+            return MetadataResponse.model_validate(data)
+        except (ValueError, ValidationError) as e:
+            raise LocalInferenceError(f"Failed to parse metadata response: {e}")
+
+    def close(self) -> None:
+        """Release model resources."""
+        if self._model is not None:
+            del self._model
+            self._model = None
+            del self._processor
+            self._processor = None
+
+            try:
+                import torch
+
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except ImportError:
+                pass
+
+            logger.info("Released Qwen2-VL model resources")
+
+    def __enter__(self) -> "QwenLocalClient":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()

--- a/photo_score/inference/parsing.py
+++ b/photo_score/inference/parsing.py
@@ -1,0 +1,46 @@
+"""Shared JSON extraction from model responses."""
+
+import json
+import re
+
+
+def extract_json_from_response(content: str) -> dict:
+    """Extract JSON object from a model response string.
+
+    Handles:
+    - Markdown code blocks (```json ... ```)
+    - Balanced brace extraction
+    - Trailing text after JSON
+
+    Raises:
+        ValueError: If no valid JSON found.
+    """
+    # First try markdown code block
+    code_block_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", content, re.DOTALL)
+    if code_block_match:
+        try:
+            return json.loads(code_block_match.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # Find first { and match balanced braces
+    start_idx = content.find("{")
+    if start_idx == -1:
+        raise ValueError(f"No JSON found in response: {content}")
+
+    depth = 0
+    end_idx = start_idx
+    for i, char in enumerate(content[start_idx:], start_idx):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                end_idx = i + 1
+                break
+
+    json_str = content[start_idx:end_idx]
+    try:
+        return json.loads(json_str)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in response: {e}\nContent: {content}")

--- a/photo_score/storage/cache.py
+++ b/photo_score/storage/cache.py
@@ -52,28 +52,31 @@ class Cache:
             """)
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS normalized_attributes (
-                    image_id TEXT PRIMARY KEY,
+                    image_id TEXT NOT NULL,
                     composition REAL NOT NULL,
                     subject_strength REAL NOT NULL,
                     visual_appeal REAL NOT NULL,
                     sharpness REAL NOT NULL,
                     exposure_balance REAL NOT NULL,
                     noise_level REAL NOT NULL,
-                    model_name TEXT,
-                    model_version TEXT,
+                    model_name TEXT NOT NULL DEFAULT 'unknown',
+                    model_version TEXT NOT NULL DEFAULT 'unknown',
                     scored_at TEXT,
-                    synced_at TEXT
+                    synced_at TEXT,
+                    PRIMARY KEY (image_id, model_name, model_version)
                 )
             """)
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS image_metadata (
-                    image_id TEXT PRIMARY KEY,
+                    image_id TEXT NOT NULL,
+                    model_name TEXT NOT NULL DEFAULT 'unknown',
                     date_taken TEXT,
                     latitude REAL,
                     longitude REAL,
                     description TEXT,
                     location_name TEXT,
-                    location_country TEXT
+                    location_country TEXT,
+                    PRIMARY KEY (image_id, model_name)
                 )
             """)
             conn.execute("""
@@ -88,20 +91,124 @@ class Cache:
             conn.commit()
 
     def _migrate_schema(self) -> None:
-        """Add new columns to existing databases."""
+        """Migrate old schemas to current version."""
         with sqlite3.connect(self.db_path) as conn:
-            # Get existing columns
+            # --- Migrate normalized_attributes ---
             cursor = conn.execute("PRAGMA table_info(normalized_attributes)")
-            existing = {row[1] for row in cursor.fetchall()}
+            columns = {row[1]: row for row in cursor.fetchall()}
 
-            if "scored_at" not in existing:
+            # Add scored_at/synced_at if missing (v1 migration)
+            if "scored_at" not in columns:
                 conn.execute(
                     "ALTER TABLE normalized_attributes ADD COLUMN scored_at TEXT"
                 )
-            if "synced_at" not in existing:
+            if "synced_at" not in columns:
                 conn.execute(
                     "ALTER TABLE normalized_attributes ADD COLUMN synced_at TEXT"
                 )
+
+            # Check if PK is single-column (old schema: image_id TEXT PRIMARY KEY)
+            # pk column index (5th element) > 0 means it's part of the PK
+            pk_columns = [name for name, row in columns.items() if row[5] > 0]
+            if pk_columns == ["image_id"]:
+                # Old single-column PK — migrate to composite PK
+                conn.execute(
+                    "UPDATE normalized_attributes SET model_name = 'unknown' WHERE model_name IS NULL"
+                )
+                conn.execute(
+                    "UPDATE normalized_attributes SET model_version = 'unknown' WHERE model_version IS NULL"
+                )
+                conn.execute("""
+                    CREATE TABLE normalized_attributes_new (
+                        image_id TEXT NOT NULL,
+                        composition REAL NOT NULL,
+                        subject_strength REAL NOT NULL,
+                        visual_appeal REAL NOT NULL,
+                        sharpness REAL NOT NULL,
+                        exposure_balance REAL NOT NULL,
+                        noise_level REAL NOT NULL,
+                        model_name TEXT NOT NULL DEFAULT 'unknown',
+                        model_version TEXT NOT NULL DEFAULT 'unknown',
+                        scored_at TEXT,
+                        synced_at TEXT,
+                        PRIMARY KEY (image_id, model_name, model_version)
+                    )
+                """)
+                conn.execute("""
+                    INSERT INTO normalized_attributes_new
+                    SELECT image_id, composition, subject_strength, visual_appeal,
+                           sharpness, exposure_balance, noise_level,
+                           model_name, model_version, scored_at, synced_at
+                    FROM normalized_attributes
+                """)
+                conn.execute("DROP TABLE normalized_attributes")
+                conn.execute(
+                    "ALTER TABLE normalized_attributes_new RENAME TO normalized_attributes"
+                )
+
+            # --- Migrate image_metadata ---
+            cursor = conn.execute("PRAGMA table_info(image_metadata)")
+            meta_columns = {row[1]: row for row in cursor.fetchall()}
+
+            if "model_name" not in meta_columns:
+                # Old schema without model_name — add column and migrate to composite PK
+                conn.execute("""
+                    CREATE TABLE image_metadata_new (
+                        image_id TEXT NOT NULL,
+                        model_name TEXT NOT NULL DEFAULT 'unknown',
+                        date_taken TEXT,
+                        latitude REAL,
+                        longitude REAL,
+                        description TEXT,
+                        location_name TEXT,
+                        location_country TEXT,
+                        PRIMARY KEY (image_id, model_name)
+                    )
+                """)
+                conn.execute("""
+                    INSERT INTO image_metadata_new
+                    (image_id, model_name, date_taken, latitude, longitude,
+                     description, location_name, location_country)
+                    SELECT image_id, 'unknown', date_taken, latitude, longitude,
+                           description, location_name, location_country
+                    FROM image_metadata
+                """)
+                conn.execute("DROP TABLE image_metadata")
+                conn.execute("ALTER TABLE image_metadata_new RENAME TO image_metadata")
+            else:
+                # model_name column exists — check if PK needs migration
+                meta_pk_columns = [
+                    name for name, row in meta_columns.items() if row[5] > 0
+                ]
+                if meta_pk_columns == ["image_id"]:
+                    # Single-column PK with model_name column — migrate to composite PK
+                    conn.execute(
+                        "UPDATE image_metadata SET model_name = 'unknown' WHERE model_name IS NULL"
+                    )
+                    conn.execute("""
+                        CREATE TABLE image_metadata_new (
+                            image_id TEXT NOT NULL,
+                            model_name TEXT NOT NULL DEFAULT 'unknown',
+                            date_taken TEXT,
+                            latitude REAL,
+                            longitude REAL,
+                            description TEXT,
+                            location_name TEXT,
+                            location_country TEXT,
+                            PRIMARY KEY (image_id, model_name)
+                        )
+                    """)
+                    conn.execute("""
+                        INSERT INTO image_metadata_new
+                        SELECT image_id, model_name, date_taken, latitude, longitude,
+                               description, location_name, location_country
+                        FROM image_metadata
+                    """)
+                    conn.execute("DROP TABLE image_metadata")
+                    conn.execute(
+                        "ALTER TABLE image_metadata_new RENAME TO image_metadata"
+                    )
+
             conn.commit()
 
     def get_inference(
@@ -154,14 +261,41 @@ class Cache:
             )
             conn.commit()
 
-    def get_attributes(self, image_id: str) -> NormalizedAttributes | None:
-        """Retrieve cached normalized attributes."""
+    def get_attributes(
+        self,
+        image_id: str,
+        model_name: str | None = None,
+        model_version: str | None = None,
+    ) -> NormalizedAttributes | None:
+        """Retrieve cached normalized attributes.
+
+        Args:
+            image_id: Image hash.
+            model_name: If provided, filter to this model.
+            model_version: If provided, filter to this version.
+
+        When all three are provided, does exact PK lookup.
+        When partial/none, returns most recent by scored_at.
+        """
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
-            cursor = conn.execute(
-                "SELECT * FROM normalized_attributes WHERE image_id = ?",
-                (image_id,),
-            )
+
+            if model_name is not None and model_version is not None:
+                cursor = conn.execute(
+                    "SELECT * FROM normalized_attributes WHERE image_id = ? AND model_name = ? AND model_version = ?",
+                    (image_id, model_name, model_version),
+                )
+            elif model_name is not None:
+                cursor = conn.execute(
+                    "SELECT * FROM normalized_attributes WHERE image_id = ? AND model_name = ? ORDER BY scored_at DESC LIMIT 1",
+                    (image_id, model_name),
+                )
+            else:
+                cursor = conn.execute(
+                    "SELECT * FROM normalized_attributes WHERE image_id = ? ORDER BY scored_at DESC LIMIT 1",
+                    (image_id,),
+                )
+
             row = cursor.fetchone()
             if row is None:
                 return None
@@ -186,7 +320,8 @@ class Cache:
     def store_attributes(self, attributes: NormalizedAttributes) -> None:
         """Store normalized attributes in cache.
 
-        Uses INSERT ... ON CONFLICT to preserve synced_at on updates.
+        Uses INSERT ... ON CONFLICT on composite PK (image_id, model_name, model_version)
+        to preserve synced_at on updates.
         """
         scored_at_str = None
         if attributes.scored_at is not None:
@@ -200,15 +335,13 @@ class Cache:
                  sharpness, exposure_balance, noise_level, model_name, model_version,
                  scored_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(image_id) DO UPDATE SET
+                ON CONFLICT(image_id, model_name, model_version) DO UPDATE SET
                     composition = excluded.composition,
                     subject_strength = excluded.subject_strength,
                     visual_appeal = excluded.visual_appeal,
                     sharpness = excluded.sharpness,
                     exposure_balance = excluded.exposure_balance,
                     noise_level = excluded.noise_level,
-                    model_name = excluded.model_name,
-                    model_version = excluded.model_version,
                     scored_at = excluded.scored_at
                 """,
                 (
@@ -226,29 +359,59 @@ class Cache:
             )
             conn.commit()
 
-    def mark_synced(self, image_ids: list[str]) -> None:
-        """Mark attributes as synced by setting synced_at to now (UTC)."""
-        if not image_ids:
+    def mark_synced(self, rows: list[tuple[str, str, str]] | list[str]) -> None:
+        """Mark attributes as synced by setting synced_at to now (UTC).
+
+        Args:
+            rows: List of (image_id, model_name, model_version) tuples,
+                  or list of image_ids for backward compatibility.
+        """
+        if not rows:
             return
         now = datetime.now(timezone.utc).isoformat()
         with sqlite3.connect(self.db_path) as conn:
-            placeholders = ",".join("?" for _ in image_ids)
-            conn.execute(
-                f"UPDATE normalized_attributes SET synced_at = ? WHERE image_id IN ({placeholders})",
-                [now, *image_ids],
-            )
+            # Detect whether caller passed tuples or plain strings
+            if isinstance(rows[0], str):
+                # Backward compat: mark all rows for these image_ids
+                placeholders = ",".join("?" for _ in rows)
+                conn.execute(
+                    f"UPDATE normalized_attributes SET synced_at = ? WHERE image_id IN ({placeholders})",
+                    [now, *rows],
+                )
+            else:
+                # New API: mark specific (image_id, model_name, model_version) rows
+                for image_id, model_name, model_version in rows:
+                    conn.execute(
+                        "UPDATE normalized_attributes SET synced_at = ? WHERE image_id = ? AND model_name = ? AND model_version = ?",
+                        (now, image_id, model_name, model_version),
+                    )
             conn.commit()
 
-    def list_unsynced_attributes(self) -> list[NormalizedAttributes]:
-        """Return attributes that have never been synced or changed since last sync."""
+    def list_unsynced_attributes(
+        self,
+        model_name: str | None = None,
+        model_version: str | None = None,
+    ) -> list[NormalizedAttributes]:
+        """Return attributes that have never been synced or changed since last sync.
+
+        Args:
+            model_name: If provided, only return rows matching this model.
+            model_version: If provided, also filter by version.
+        """
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
-            cursor = conn.execute(
-                """
-                SELECT * FROM normalized_attributes
-                WHERE synced_at IS NULL OR scored_at > synced_at
-                """
-            )
+
+            query = "SELECT * FROM normalized_attributes WHERE (synced_at IS NULL OR scored_at > synced_at)"
+            params: list = []
+
+            if model_name is not None:
+                query += " AND model_name = ?"
+                params.append(model_name)
+            if model_version is not None:
+                query += " AND model_version = ?"
+                params.append(model_version)
+
+            cursor = conn.execute(query, params)
             results = []
             for row in cursor.fetchall():
                 scored_at = None
@@ -270,22 +433,41 @@ class Cache:
                 )
             return results
 
-    def list_all_metadata_for(self, image_ids: list[str]) -> dict[str, ImageMetadata]:
-        """Batch lookup metadata by image_id list."""
+    def list_all_metadata_for(
+        self,
+        image_ids: list[str],
+        model_name: str | None = None,
+    ) -> dict[str, ImageMetadata]:
+        """Batch lookup metadata by image_id list.
+
+        Args:
+            image_ids: List of image hashes to look up.
+            model_name: If provided, return only metadata from this model.
+                        If None, return one per image_id (latest by rowid).
+        """
         if not image_ids:
             return {}
         result: dict[str, ImageMetadata] = {}
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             placeholders = ",".join("?" for _ in image_ids)
-            cursor = conn.execute(
-                f"SELECT * FROM image_metadata WHERE image_id IN ({placeholders})",
-                image_ids,
-            )
+
+            if model_name is not None:
+                cursor = conn.execute(
+                    f"SELECT * FROM image_metadata WHERE image_id IN ({placeholders}) AND model_name = ?",
+                    [*image_ids, model_name],
+                )
+            else:
+                cursor = conn.execute(
+                    f"SELECT * FROM image_metadata WHERE image_id IN ({placeholders})",
+                    image_ids,
+                )
+
             for row in cursor.fetchall():
                 date_taken = None
                 if row["date_taken"]:
                     date_taken = datetime.fromisoformat(row["date_taken"])
+                # When no model filter, last row wins (one per image_id)
                 result[row["image_id"]] = ImageMetadata(
                     date_taken=date_taken,
                     latitude=row["latitude"],
@@ -296,23 +478,57 @@ class Cache:
                 )
         return result
 
-    def has_attributes(self, image_id: str) -> bool:
+    def has_attributes(
+        self,
+        image_id: str,
+        model_name: str | None = None,
+        model_version: str | None = None,
+    ) -> bool:
         """Check if attributes exist for an image."""
         with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.execute(
-                "SELECT 1 FROM normalized_attributes WHERE image_id = ?",
-                (image_id,),
-            )
+            if model_name is not None and model_version is not None:
+                cursor = conn.execute(
+                    "SELECT 1 FROM normalized_attributes WHERE image_id = ? AND model_name = ? AND model_version = ?",
+                    (image_id, model_name, model_version),
+                )
+            elif model_name is not None:
+                cursor = conn.execute(
+                    "SELECT 1 FROM normalized_attributes WHERE image_id = ? AND model_name = ?",
+                    (image_id, model_name),
+                )
+            else:
+                cursor = conn.execute(
+                    "SELECT 1 FROM normalized_attributes WHERE image_id = ?",
+                    (image_id,),
+                )
             return cursor.fetchone() is not None
 
-    def get_metadata(self, image_id: str) -> Optional[ImageMetadata]:
-        """Retrieve cached image metadata."""
+    def get_metadata(
+        self,
+        image_id: str,
+        model_name: str | None = None,
+    ) -> Optional[ImageMetadata]:
+        """Retrieve cached image metadata.
+
+        Args:
+            image_id: Image hash.
+            model_name: If provided, exact (image_id, model_name) lookup.
+                        If None, returns latest by rowid (backward compat).
+        """
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
-            cursor = conn.execute(
-                "SELECT * FROM image_metadata WHERE image_id = ?",
-                (image_id,),
-            )
+
+            if model_name is not None:
+                cursor = conn.execute(
+                    "SELECT * FROM image_metadata WHERE image_id = ? AND model_name = ?",
+                    (image_id, model_name),
+                )
+            else:
+                cursor = conn.execute(
+                    "SELECT * FROM image_metadata WHERE image_id = ? ORDER BY rowid DESC LIMIT 1",
+                    (image_id,),
+                )
+
             row = cursor.fetchone()
             if row is None:
                 return None
@@ -330,7 +546,12 @@ class Cache:
                 location_country=row["location_country"],
             )
 
-    def store_metadata(self, image_id: str, metadata: ImageMetadata) -> None:
+    def store_metadata(
+        self,
+        image_id: str,
+        metadata: ImageMetadata,
+        model_name: str = "unknown",
+    ) -> None:
         """Store image metadata in cache."""
         date_str = None
         if metadata.date_taken:
@@ -340,11 +561,12 @@ class Cache:
             conn.execute(
                 """
                 INSERT OR REPLACE INTO image_metadata
-                (image_id, date_taken, latitude, longitude, description, location_name, location_country)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (image_id, model_name, date_taken, latitude, longitude, description, location_name, location_country)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     image_id,
+                    model_name,
                     date_str,
                     metadata.latitude,
                     metadata.longitude,
@@ -355,13 +577,23 @@ class Cache:
             )
             conn.commit()
 
-    def has_metadata(self, image_id: str) -> bool:
+    def has_metadata(
+        self,
+        image_id: str,
+        model_name: str | None = None,
+    ) -> bool:
         """Check if metadata exists for an image."""
         with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.execute(
-                "SELECT 1 FROM image_metadata WHERE image_id = ?",
-                (image_id,),
-            )
+            if model_name is not None:
+                cursor = conn.execute(
+                    "SELECT 1 FROM image_metadata WHERE image_id = ? AND model_name = ?",
+                    (image_id, model_name),
+                )
+            else:
+                cursor = conn.execute(
+                    "SELECT 1 FROM image_metadata WHERE image_id = ?",
+                    (image_id,),
+                )
             return cursor.fetchone() is not None
 
     def get_critique(self, image_id: str) -> Optional[dict]:

--- a/photo_score/storage/cache.py
+++ b/photo_score/storage/cache.py
@@ -15,6 +15,12 @@ from photo_score.storage.models import (
 DEFAULT_CACHE_DIR = Path.home() / ".photo_score"
 DEFAULT_CACHE_DB = DEFAULT_CACHE_DIR / "cache.db"
 
+# Legacy migration identity: all pre-existing rows were produced by cloud
+# inference, so we normalize them to the canonical cloud identity that the
+# desktop sidecar filters on.  This prevents stranding rows after upgrade.
+_LEGACY_MODEL_NAME = "anthropic/claude-3.5-sonnet"
+_LEGACY_MODEL_VERSION = "cloud-v1"
+
 
 class Cache:
     """SQLite-based cache for inference results and normalized attributes."""
@@ -111,12 +117,14 @@ class Cache:
             # pk column index (5th element) > 0 means it's part of the PK
             pk_columns = [name for name, row in columns.items() if row[5] > 0]
             if pk_columns == ["image_id"]:
-                # Old single-column PK — migrate to composite PK
+                # Old single-column PK — migrate to composite PK.
+                # All pre-existing rows are from cloud inference (local didn't
+                # exist before this migration), so unconditionally normalize to
+                # the canonical cloud identity.  This keeps them visible to the
+                # desktop sidecar which filters on these exact values.
                 conn.execute(
-                    "UPDATE normalized_attributes SET model_name = 'unknown' WHERE model_name IS NULL"
-                )
-                conn.execute(
-                    "UPDATE normalized_attributes SET model_version = 'unknown' WHERE model_version IS NULL"
+                    "UPDATE normalized_attributes SET model_name = ?, model_version = ?",
+                    (_LEGACY_MODEL_NAME, _LEGACY_MODEL_VERSION),
                 )
                 conn.execute("""
                     CREATE TABLE normalized_attributes_new (
@@ -151,7 +159,8 @@ class Cache:
             meta_columns = {row[1]: row for row in cursor.fetchall()}
 
             if "model_name" not in meta_columns:
-                # Old schema without model_name — add column and migrate to composite PK
+                # Old schema without model_name — add column and migrate to composite PK.
+                # Normalize to the canonical cloud identity (same as attributes).
                 conn.execute("""
                     CREATE TABLE image_metadata_new (
                         image_id TEXT NOT NULL,
@@ -165,14 +174,17 @@ class Cache:
                         PRIMARY KEY (image_id, model_name)
                     )
                 """)
-                conn.execute("""
+                conn.execute(
+                    """
                     INSERT INTO image_metadata_new
                     (image_id, model_name, date_taken, latitude, longitude,
                      description, location_name, location_country)
-                    SELECT image_id, 'unknown', date_taken, latitude, longitude,
+                    SELECT image_id, ?, date_taken, latitude, longitude,
                            description, location_name, location_country
                     FROM image_metadata
-                """)
+                """,
+                    (_LEGACY_MODEL_NAME,),
+                )
                 conn.execute("DROP TABLE image_metadata")
                 conn.execute("ALTER TABLE image_metadata_new RENAME TO image_metadata")
             else:
@@ -181,9 +193,11 @@ class Cache:
                     name for name, row in meta_columns.items() if row[5] > 0
                 ]
                 if meta_pk_columns == ["image_id"]:
-                    # Single-column PK with model_name column — migrate to composite PK
+                    # Single-column PK with model_name column — migrate to composite PK.
+                    # Unconditionally normalize (same rationale as attributes).
                     conn.execute(
-                        "UPDATE image_metadata SET model_name = 'unknown' WHERE model_name IS NULL"
+                        "UPDATE image_metadata SET model_name = ?",
+                        (_LEGACY_MODEL_NAME,),
                     )
                     conn.execute("""
                         CREATE TABLE image_metadata_new (

--- a/photo_score/storage/cache.py
+++ b/photo_score/storage/cache.py
@@ -118,13 +118,24 @@ class Cache:
             pk_columns = [name for name, row in columns.items() if row[5] > 0]
             if pk_columns == ["image_id"]:
                 # Old single-column PK — migrate to composite PK.
-                # All pre-existing rows are from cloud inference (local didn't
-                # exist before this migration), so unconditionally normalize to
-                # the canonical cloud identity.  This keeps them visible to the
-                # desktop sidecar which filters on these exact values.
+                # Only normalize rows that lack a real model identity (NULL or
+                # 'unknown') to the canonical cloud pair.  Rows that already
+                # carry an explicit model_name (e.g. google/gemini-*) are
+                # preserved as-is; overwriting them would be data corruption.
                 conn.execute(
-                    "UPDATE normalized_attributes SET model_name = ?, model_version = ?",
+                    """UPDATE normalized_attributes
+                       SET model_name = ?, model_version = ?
+                       WHERE model_name IS NULL
+                          OR model_name = ''
+                          OR model_name = 'unknown'""",
                     (_LEGACY_MODEL_NAME, _LEGACY_MODEL_VERSION),
+                )
+                # Rows with an explicit model_name but NULL/unknown version
+                # get the version backfilled so the NOT NULL constraint holds.
+                conn.execute(
+                    """UPDATE normalized_attributes
+                       SET model_version = 'unknown'
+                       WHERE model_version IS NULL""",
                 )
                 conn.execute("""
                     CREATE TABLE normalized_attributes_new (
@@ -194,9 +205,12 @@ class Cache:
                 ]
                 if meta_pk_columns == ["image_id"]:
                     # Single-column PK with model_name column — migrate to composite PK.
-                    # Unconditionally normalize (same rationale as attributes).
+                    # Only normalize NULL/empty/unknown rows; preserve explicit identities.
                     conn.execute(
-                        "UPDATE image_metadata SET model_name = ?",
+                        """UPDATE image_metadata SET model_name = ?
+                           WHERE model_name IS NULL
+                              OR model_name = ''
+                              OR model_name = 'unknown'""",
                         (_LEGACY_MODEL_NAME,),
                     )
                     conn.execute("""

--- a/photo_score/storage/models.py
+++ b/photo_score/storage/models.py
@@ -43,8 +43,8 @@ class NormalizedAttributes(BaseModel):
     noise_level: float = Field(ge=0.0, le=1.0)
 
     # Metadata
-    model_name: Optional[str] = None
-    model_version: Optional[str] = None
+    model_name: str = Field(default="unknown")
+    model_version: str = Field(default="unknown")
     scored_at: Optional[datetime] = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.8.0",
 ]
+local = [
+    "torch>=2.1.0",
+    "transformers>=4.45.0",
+    "accelerate>=0.25.0",
+    "huggingface-hub>=0.20.0",
+    "qwen-vl-utils>=0.0.2",
+    "bitsandbytes>=0.41.0",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ local = [
     "accelerate>=0.25.0",
     "huggingface-hub>=0.20.0",
     "qwen-vl-utils>=0.0.2",
-    "bitsandbytes>=0.41.0",
+    "bitsandbytes>=0.41.0; sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64') or sys_platform == 'win32'",
 ]
 
 [dependency-groups]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,7 +2,7 @@
 
 import sqlite3
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 import pytest
@@ -19,25 +19,37 @@ def temp_cache() -> Cache:
         yield Cache(db_path)
 
 
+def _make_attrs(
+    image_id: str = "abc123",
+    composition: float = 0.8,
+    model_name: str = "test/model",
+    model_version: str = "1.0",
+    scored_at: datetime | None = None,
+    **kwargs,
+) -> NormalizedAttributes:
+    """Helper to create NormalizedAttributes with sensible defaults."""
+    return NormalizedAttributes(
+        image_id=image_id,
+        composition=composition,
+        subject_strength=kwargs.get("subject_strength", 0.7),
+        visual_appeal=kwargs.get("visual_appeal", 0.6),
+        sharpness=kwargs.get("sharpness", 0.9),
+        exposure_balance=kwargs.get("exposure_balance", 0.85),
+        noise_level=kwargs.get("noise_level", 0.75),
+        model_name=model_name,
+        model_version=model_version,
+        scored_at=scored_at,
+    )
+
+
 class TestCache:
     """Tests for Cache class."""
 
     def test_store_and_retrieve_attributes(self, temp_cache: Cache):
         """Should store and retrieve attributes correctly."""
-        attrs = NormalizedAttributes(
-            image_id="abc123",
-            composition=0.8,
-            subject_strength=0.7,
-            visual_appeal=0.6,
-            sharpness=0.9,
-            exposure_balance=0.85,
-            noise_level=0.75,
-            model_name="test/model",
-            model_version="1.0",
-        )
-
+        attrs = _make_attrs()
         temp_cache.store_attributes(attrs)
-        retrieved = temp_cache.get_attributes("abc123")
+        retrieved = temp_cache.get_attributes("abc123", "test/model", "1.0")
 
         assert retrieved is not None
         assert retrieved.image_id == attrs.image_id
@@ -51,15 +63,7 @@ class TestCache:
 
     def test_has_attributes(self, temp_cache: Cache):
         """Should correctly check for attribute existence."""
-        attrs = NormalizedAttributes(
-            image_id="exists123",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-        )
+        attrs = _make_attrs(image_id="exists123", composition=0.5)
 
         assert not temp_cache.has_attributes("exists123")
         temp_cache.store_attributes(attrs)
@@ -106,31 +110,172 @@ class TestCache:
         assert v2.raw_response == response_v2
 
     def test_update_existing_attributes(self, temp_cache: Cache):
-        """Storing attributes again should update existing entry."""
-        attrs1 = NormalizedAttributes(
-            image_id="update_test",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-        )
-        attrs2 = NormalizedAttributes(
-            image_id="update_test",
-            composition=0.9,  # Changed
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-        )
+        """Storing attributes again with same PK should update existing entry."""
+        attrs1 = _make_attrs(image_id="update_test", composition=0.5)
+        attrs2 = _make_attrs(image_id="update_test", composition=0.9)
 
         temp_cache.store_attributes(attrs1)
         temp_cache.store_attributes(attrs2)
 
-        retrieved = temp_cache.get_attributes("update_test")
+        retrieved = temp_cache.get_attributes("update_test", "test/model", "1.0")
         assert retrieved.composition == 0.9
+
+
+class TestCompositeKeyAttributes:
+    """Tests for multi-model attribute coexistence."""
+
+    def test_cloud_and_local_attrs_coexist(self, temp_cache: Cache):
+        """Cloud and local attrs for same image should both exist."""
+        cloud = _make_attrs(
+            image_id="img1",
+            model_name="anthropic/claude-3.5-sonnet",
+            model_version="20241022",
+            composition=0.8,
+        )
+        local = _make_attrs(
+            image_id="img1",
+            model_name="local/qwen2-vl-2b-instruct",
+            model_version="1.0",
+            composition=0.6,
+        )
+
+        temp_cache.store_attributes(cloud)
+        temp_cache.store_attributes(local)
+
+        got_cloud = temp_cache.get_attributes(
+            "img1", "anthropic/claude-3.5-sonnet", "20241022"
+        )
+        got_local = temp_cache.get_attributes(
+            "img1", "local/qwen2-vl-2b-instruct", "1.0"
+        )
+
+        assert got_cloud is not None
+        assert got_local is not None
+        assert got_cloud.composition == 0.8
+        assert got_local.composition == 0.6
+
+    def test_get_attributes_no_filter_returns_latest(self, temp_cache: Cache):
+        """get_attributes with no model filter returns most recent by scored_at."""
+        old_time = datetime.now(timezone.utc) - timedelta(hours=1)
+        new_time = datetime.now(timezone.utc)
+
+        old = _make_attrs(
+            image_id="img1",
+            model_name="model/old",
+            model_version="1.0",
+            scored_at=old_time,
+            composition=0.3,
+        )
+        new = _make_attrs(
+            image_id="img1",
+            model_name="model/new",
+            model_version="2.0",
+            scored_at=new_time,
+            composition=0.9,
+        )
+
+        temp_cache.store_attributes(old)
+        temp_cache.store_attributes(new)
+
+        latest = temp_cache.get_attributes("img1")
+        assert latest is not None
+        assert latest.composition == 0.9
+
+    def test_has_attributes_with_model_filter(self, temp_cache: Cache):
+        """has_attributes should filter by model when provided."""
+        attrs = _make_attrs(
+            image_id="img1",
+            model_name="cloud/model",
+            model_version="v1",
+        )
+        temp_cache.store_attributes(attrs)
+
+        assert temp_cache.has_attributes("img1", "cloud/model", "v1")
+        assert not temp_cache.has_attributes("img1", "local/model", "v1")
+        assert temp_cache.has_attributes("img1")  # no filter
+
+    def test_has_attributes_model_name_only(self, temp_cache: Cache):
+        """has_attributes with model_name only should work."""
+        attrs = _make_attrs(
+            image_id="img1",
+            model_name="cloud/model",
+            model_version="v1",
+        )
+        temp_cache.store_attributes(attrs)
+
+        assert temp_cache.has_attributes("img1", model_name="cloud/model")
+        assert not temp_cache.has_attributes("img1", model_name="local/model")
+
+
+class TestCompositeKeyMetadata:
+    """Tests for multi-model metadata coexistence."""
+
+    def test_cloud_and_local_metadata_coexist(self, temp_cache: Cache):
+        """Cloud and local metadata for same image should both exist."""
+        cloud_meta = ImageMetadata(
+            description="Cloud description", location_name="Paris"
+        )
+        local_meta = ImageMetadata(
+            description="Local description", location_name="Lyon"
+        )
+
+        temp_cache.store_metadata("img1", cloud_meta, model_name="cloud/model")
+        temp_cache.store_metadata("img1", local_meta, model_name="local/model")
+
+        got_cloud = temp_cache.get_metadata("img1", model_name="cloud/model")
+        got_local = temp_cache.get_metadata("img1", model_name="local/model")
+
+        assert got_cloud is not None
+        assert got_local is not None
+        assert got_cloud.description == "Cloud description"
+        assert got_local.description == "Local description"
+
+    def test_get_metadata_no_filter_returns_one(self, temp_cache: Cache):
+        """get_metadata with no model filter returns a result."""
+        meta = ImageMetadata(description="test")
+        temp_cache.store_metadata("img1", meta, model_name="some/model")
+
+        result = temp_cache.get_metadata("img1")
+        assert result is not None
+        assert result.description == "test"
+
+    def test_has_metadata_with_model_filter(self, temp_cache: Cache):
+        """has_metadata should filter by model when provided."""
+        meta = ImageMetadata(description="test")
+        temp_cache.store_metadata("img1", meta, model_name="cloud/model")
+
+        assert temp_cache.has_metadata("img1", model_name="cloud/model")
+        assert not temp_cache.has_metadata("img1", model_name="local/model")
+        assert temp_cache.has_metadata("img1")  # no filter
+
+    def test_list_all_metadata_for_with_model_filter(self, temp_cache: Cache):
+        """list_all_metadata_for should filter by model_name."""
+        cloud_meta = ImageMetadata(description="Cloud")
+        local_meta = ImageMetadata(description="Local")
+
+        temp_cache.store_metadata("img1", cloud_meta, model_name="cloud/model")
+        temp_cache.store_metadata("img1", local_meta, model_name="local/model")
+        temp_cache.store_metadata("img2", cloud_meta, model_name="cloud/model")
+
+        result = temp_cache.list_all_metadata_for(
+            ["img1", "img2"], model_name="cloud/model"
+        )
+        assert len(result) == 2
+        assert result["img1"].description == "Cloud"
+        assert result["img2"].description == "Cloud"
+
+    def test_list_all_metadata_for_without_filter(self, temp_cache: Cache):
+        """list_all_metadata_for without filter returns one per image."""
+        meta1 = ImageMetadata(description="Photo 1", location_name="Paris")
+        meta2 = ImageMetadata(description="Photo 2", location_country="Japan")
+
+        temp_cache.store_metadata("img1", meta1)
+        temp_cache.store_metadata("img2", meta2)
+
+        result = temp_cache.list_all_metadata_for(["img1", "img2"])
+        assert len(result) == 2
+        assert result["img1"].description == "Photo 1"
+        assert result["img2"].description == "Photo 2"
 
 
 class TestSyncFeatures:
@@ -139,53 +284,26 @@ class TestSyncFeatures:
     def test_scored_at_roundtrips(self, temp_cache: Cache):
         """scored_at should round-trip through store/get."""
         now = datetime.now(timezone.utc)
-        attrs = NormalizedAttributes(
-            image_id="scored1",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-            scored_at=now,
-        )
+        attrs = _make_attrs(image_id="scored1", scored_at=now)
         temp_cache.store_attributes(attrs)
-        retrieved = temp_cache.get_attributes("scored1")
+        retrieved = temp_cache.get_attributes("scored1", "test/model", "1.0")
         assert retrieved is not None
         assert retrieved.scored_at is not None
         assert retrieved.scored_at.isoformat() == now.isoformat()
 
     def test_scored_at_none_roundtrips(self, temp_cache: Cache):
         """scored_at=None should round-trip as None."""
-        attrs = NormalizedAttributes(
-            image_id="scored_none",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-            scored_at=None,
-        )
+        attrs = _make_attrs(image_id="scored_none", scored_at=None)
         temp_cache.store_attributes(attrs)
-        retrieved = temp_cache.get_attributes("scored_none")
+        retrieved = temp_cache.get_attributes("scored_none", "test/model", "1.0")
         assert retrieved is not None
         assert retrieved.scored_at is None
 
     def test_synced_at_none_on_fresh_store(self, temp_cache: Cache):
         """synced_at should be None after initial store."""
-        attrs = NormalizedAttributes(
-            image_id="fresh1",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-        )
+        attrs = _make_attrs(image_id="fresh1")
         temp_cache.store_attributes(attrs)
 
-        # Check directly in DB that synced_at is NULL
         with sqlite3.connect(temp_cache.db_path) as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
@@ -194,19 +312,11 @@ class TestSyncFeatures:
             ).fetchone()
             assert row["synced_at"] is None
 
-    def test_mark_synced_sets_synced_at(self, temp_cache: Cache):
-        """mark_synced should set synced_at for given ids."""
-        attrs = NormalizedAttributes(
-            image_id="sync1",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-        )
+    def test_mark_synced_with_tuples(self, temp_cache: Cache):
+        """mark_synced with (image_id, model_name, model_version) tuples should work."""
+        attrs = _make_attrs(image_id="sync1")
         temp_cache.store_attributes(attrs)
-        temp_cache.mark_synced(["sync1"])
+        temp_cache.mark_synced([("sync1", "test/model", "1.0")])
 
         with sqlite3.connect(temp_cache.db_path) as conn:
             conn.row_factory = sqlite3.Row
@@ -216,38 +326,92 @@ class TestSyncFeatures:
             ).fetchone()
             assert row["synced_at"] is not None
 
+    def test_mark_synced_with_strings_backward_compat(self, temp_cache: Cache):
+        """mark_synced with plain image_id strings should still work."""
+        attrs = _make_attrs(image_id="sync_str")
+        temp_cache.store_attributes(attrs)
+        temp_cache.mark_synced(["sync_str"])
+
+        with sqlite3.connect(temp_cache.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT synced_at FROM normalized_attributes WHERE image_id = ?",
+                ("sync_str",),
+            ).fetchone()
+            assert row["synced_at"] is not None
+
+    def test_mark_synced_targets_specific_row(self, temp_cache: Cache):
+        """mark_synced with tuples should only mark the exact row."""
+        cloud = _make_attrs(
+            image_id="img1",
+            model_name="cloud/model",
+            model_version="v1",
+        )
+        local = _make_attrs(
+            image_id="img1",
+            model_name="local/model",
+            model_version="v1",
+        )
+        temp_cache.store_attributes(cloud)
+        temp_cache.store_attributes(local)
+
+        # Mark only cloud row as synced
+        temp_cache.mark_synced([("img1", "cloud/model", "v1")])
+
+        with sqlite3.connect(temp_cache.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cloud_row = conn.execute(
+                "SELECT synced_at FROM normalized_attributes WHERE image_id = ? AND model_name = ?",
+                ("img1", "cloud/model"),
+            ).fetchone()
+            local_row = conn.execute(
+                "SELECT synced_at FROM normalized_attributes WHERE image_id = ? AND model_name = ?",
+                ("img1", "local/model"),
+            ).fetchone()
+
+            assert cloud_row["synced_at"] is not None
+            assert local_row["synced_at"] is None
+
     def test_list_unsynced_returns_new_rows(self, temp_cache: Cache):
         """list_unsynced_attributes should return rows with synced_at IS NULL."""
-        attrs = NormalizedAttributes(
-            image_id="unsynced1",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-        )
+        attrs = _make_attrs(image_id="unsynced1")
         temp_cache.store_attributes(attrs)
 
         unsynced = temp_cache.list_unsynced_attributes()
         ids = [a.image_id for a in unsynced]
         assert "unsynced1" in ids
 
+    def test_list_unsynced_with_model_filter(self, temp_cache: Cache):
+        """list_unsynced_attributes should filter by model when provided."""
+        cloud = _make_attrs(
+            image_id="img1", model_name="cloud/model", model_version="v1"
+        )
+        local = _make_attrs(
+            image_id="img1", model_name="local/model", model_version="v1"
+        )
+        temp_cache.store_attributes(cloud)
+        temp_cache.store_attributes(local)
+
+        cloud_unsynced = temp_cache.list_unsynced_attributes(
+            model_name="cloud/model", model_version="v1"
+        )
+        local_unsynced = temp_cache.list_unsynced_attributes(
+            model_name="local/model", model_version="v1"
+        )
+        all_unsynced = temp_cache.list_unsynced_attributes()
+
+        assert len(cloud_unsynced) == 1
+        assert cloud_unsynced[0].model_name == "cloud/model"
+        assert len(local_unsynced) == 1
+        assert local_unsynced[0].model_name == "local/model"
+        assert len(all_unsynced) == 2
+
     def test_mark_synced_makes_rows_no_longer_unsynced(self, temp_cache: Cache):
         """After mark_synced, rows should not appear in list_unsynced."""
         now = datetime.now(timezone.utc)
-        attrs = NormalizedAttributes(
-            image_id="will_sync",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-            scored_at=now,
-        )
+        attrs = _make_attrs(image_id="will_sync", scored_at=now)
         temp_cache.store_attributes(attrs)
-        temp_cache.mark_synced(["will_sync"])
+        temp_cache.mark_synced([("will_sync", "test/model", "1.0")])
 
         unsynced = temp_cache.list_unsynced_attributes()
         ids = [a.image_id for a in unsynced]
@@ -255,21 +419,10 @@ class TestSyncFeatures:
 
     def test_list_unsynced_returns_changed_rows(self, temp_cache: Cache):
         """Rows with scored_at > synced_at should appear as unsynced."""
-        from datetime import timedelta
-
         old_time = datetime.now(timezone.utc) - timedelta(hours=1)
-        attrs = NormalizedAttributes(
-            image_id="changed1",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-            scored_at=old_time,
-        )
+        attrs = _make_attrs(image_id="changed1", scored_at=old_time)
         temp_cache.store_attributes(attrs)
-        temp_cache.mark_synced(["changed1"])
+        temp_cache.mark_synced([("changed1", "test/model", "1.0")])
 
         # Now re-score with newer scored_at
         new_time = datetime.now(timezone.utc)
@@ -282,17 +435,9 @@ class TestSyncFeatures:
 
     def test_store_preserves_synced_at(self, temp_cache: Cache):
         """store_attributes should not null out synced_at on update."""
-        attrs = NormalizedAttributes(
-            image_id="preserve1",
-            composition=0.5,
-            subject_strength=0.5,
-            visual_appeal=0.5,
-            sharpness=0.5,
-            exposure_balance=0.5,
-            noise_level=0.5,
-        )
+        attrs = _make_attrs(image_id="preserve1")
         temp_cache.store_attributes(attrs)
-        temp_cache.mark_synced(["preserve1"])
+        temp_cache.mark_synced([("preserve1", "test/model", "1.0")])
 
         # Update attributes (new store)
         attrs.composition = 0.9
@@ -302,26 +447,10 @@ class TestSyncFeatures:
         with sqlite3.connect(temp_cache.db_path) as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
-                "SELECT synced_at FROM normalized_attributes WHERE image_id = ?",
-                ("preserve1",),
+                "SELECT synced_at FROM normalized_attributes WHERE image_id = ? AND model_name = ? AND model_version = ?",
+                ("preserve1", "test/model", "1.0"),
             ).fetchone()
             assert row["synced_at"] is not None
-
-    def test_list_all_metadata_for(self, temp_cache: Cache):
-        """list_all_metadata_for should return correct dict for given ids."""
-        meta1 = ImageMetadata(description="Photo 1", location_name="Paris")
-        meta2 = ImageMetadata(description="Photo 2", location_country="Japan")
-
-        temp_cache.store_metadata("img1", meta1)
-        temp_cache.store_metadata("img2", meta2)
-        temp_cache.store_metadata("img3", ImageMetadata(description="Not requested"))
-
-        result = temp_cache.list_all_metadata_for(["img1", "img2"])
-        assert len(result) == 2
-        assert result["img1"].description == "Photo 1"
-        assert result["img1"].location_name == "Paris"
-        assert result["img2"].description == "Photo 2"
-        assert result["img2"].location_country == "Japan"
 
     def test_list_all_metadata_for_empty(self, temp_cache: Cache):
         """list_all_metadata_for with empty list should return empty dict."""
@@ -332,11 +461,15 @@ class TestSyncFeatures:
         """mark_synced with empty list should be a no-op."""
         temp_cache.mark_synced([])  # Should not raise
 
+
+class TestMigration:
+    """Tests for schema migration."""
+
     def test_migration_adds_columns_to_existing_db(self):
         """Migration should add scored_at and synced_at to existing DBs."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "migrate_test.db"
-            # Create DB with old schema (no scored_at/synced_at)
+            # Create DB with old schema (no scored_at/synced_at, single PK)
             with sqlite3.connect(db_path) as conn:
                 conn.execute("""
                     CREATE TABLE normalized_attributes (
@@ -351,14 +484,112 @@ class TestSyncFeatures:
                         model_version TEXT
                     )
                 """)
+                conn.execute("""
+                    CREATE TABLE image_metadata (
+                        image_id TEXT PRIMARY KEY,
+                        date_taken TEXT,
+                        latitude REAL,
+                        longitude REAL,
+                        description TEXT,
+                        location_name TEXT,
+                        location_country TEXT
+                    )
+                """)
+                # Insert test data with NULL model_name
+                conn.execute(
+                    """
+                    INSERT INTO normalized_attributes
+                    (image_id, composition, subject_strength, visual_appeal,
+                     sharpness, exposure_balance, noise_level)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                    ("old_img", 0.5, 0.5, 0.5, 0.5, 0.5, 0.5),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO image_metadata (image_id, description)
+                    VALUES (?, ?)
+                """,
+                    ("old_img", "Old description"),
+                )
                 conn.commit()
 
             # Opening Cache should trigger migration
-            Cache(db_path)
+            cache = Cache(db_path)
 
-            # Verify columns exist
+            # Verify composite PK for normalized_attributes
             with sqlite3.connect(db_path) as conn:
                 cursor = conn.execute("PRAGMA table_info(normalized_attributes)")
-                columns = {row[1] for row in cursor.fetchall()}
+                columns = {row[1]: row for row in cursor.fetchall()}
                 assert "scored_at" in columns
                 assert "synced_at" in columns
+                # Check that model_name is NOT NULL (composite PK)
+                pk_cols = [name for name, row in columns.items() if row[5] > 0]
+                assert set(pk_cols) == {"image_id", "model_name", "model_version"}
+
+            # Verify composite PK for image_metadata
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute("PRAGMA table_info(image_metadata)")
+                columns = {row[1]: row for row in cursor.fetchall()}
+                assert "model_name" in columns
+                pk_cols = [name for name, row in columns.items() if row[5] > 0]
+                assert set(pk_cols) == {"image_id", "model_name"}
+
+            # Verify old data was migrated with model_name = "unknown"
+            attrs = cache.get_attributes("old_img")
+            assert attrs is not None
+            assert attrs.model_name == "unknown"
+            assert attrs.model_version == "unknown"
+
+            meta = cache.get_metadata("old_img")
+            assert meta is not None
+            assert meta.description == "Old description"
+
+    def test_migration_is_idempotent(self):
+        """Running migration on already-migrated DB should be safe."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "idempotent.db"
+            # Create fresh cache (new schema)
+            cache1 = Cache(db_path)
+            attrs = _make_attrs(image_id="test1")
+            cache1.store_attributes(attrs)
+
+            # Open again — migration should be a no-op
+            cache2 = Cache(db_path)
+            retrieved = cache2.get_attributes("test1", "test/model", "1.0")
+            assert retrieved is not None
+            assert retrieved.composition == 0.8
+
+
+class TestDefaultModelValues:
+    """Tests for NormalizedAttributes default model values."""
+
+    def test_default_model_name_is_unknown(self):
+        """NormalizedAttributes should default model_name to 'unknown'."""
+        attrs = NormalizedAttributes(
+            image_id="test",
+            composition=0.5,
+            subject_strength=0.5,
+            visual_appeal=0.5,
+            sharpness=0.5,
+            exposure_balance=0.5,
+            noise_level=0.5,
+        )
+        assert attrs.model_name == "unknown"
+        assert attrs.model_version == "unknown"
+
+    def test_model_name_can_be_set(self):
+        """NormalizedAttributes should accept explicit model_name."""
+        attrs = NormalizedAttributes(
+            image_id="test",
+            composition=0.5,
+            subject_strength=0.5,
+            visual_appeal=0.5,
+            sharpness=0.5,
+            exposure_balance=0.5,
+            noise_level=0.5,
+            model_name="anthropic/claude-3.5-sonnet",
+            model_version="20241022",
+        )
+        assert attrs.model_name == "anthropic/claude-3.5-sonnet"
+        assert attrs.model_version == "20241022"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -570,8 +570,17 @@ class TestMigration:
                 conn.execute(
                     """INSERT INTO normalized_attributes VALUES
                        (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    ("gemini_img", 0.7, 0.7, 0.7, 0.7, 0.7, 0.7,
-                     "google/gemini-1.5-pro", "exp-42"),
+                    (
+                        "gemini_img",
+                        0.7,
+                        0.7,
+                        0.7,
+                        0.7,
+                        0.7,
+                        0.7,
+                        "google/gemini-1.5-pro",
+                        "exp-42",
+                    ),
                 )
                 # Row with NULL model (genuinely legacy)
                 conn.execute(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -535,11 +535,11 @@ class TestMigration:
                 pk_cols = [name for name, row in columns.items() if row[5] > 0]
                 assert set(pk_cols) == {"image_id", "model_name"}
 
-            # Verify old data was migrated with model_name = "unknown"
+            # Verify old data was migrated to canonical cloud identity
             attrs = cache.get_attributes("old_img")
             assert attrs is not None
-            assert attrs.model_name == "unknown"
-            assert attrs.model_version == "unknown"
+            assert attrs.model_name == "anthropic/claude-3.5-sonnet"
+            assert attrs.model_version == "cloud-v1"
 
             meta = cache.get_metadata("old_img")
             assert meta is not None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -545,6 +545,77 @@ class TestMigration:
             assert meta is not None
             assert meta.description == "Old description"
 
+    def test_migration_preserves_explicit_model_identity(self):
+        """Rows with explicit model_name should NOT be overwritten to cloud identity."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "explicit_model.db"
+
+            import sqlite3
+
+            with sqlite3.connect(db_path) as conn:
+                conn.execute("""
+                    CREATE TABLE normalized_attributes (
+                        image_id TEXT PRIMARY KEY,
+                        composition REAL NOT NULL,
+                        subject_strength REAL NOT NULL,
+                        visual_appeal REAL NOT NULL,
+                        sharpness REAL NOT NULL,
+                        exposure_balance REAL NOT NULL,
+                        noise_level REAL NOT NULL,
+                        model_name TEXT,
+                        model_version TEXT
+                    )
+                """)
+                # Row with explicit non-default model identity
+                conn.execute(
+                    """INSERT INTO normalized_attributes VALUES
+                       (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    ("gemini_img", 0.7, 0.7, 0.7, 0.7, 0.7, 0.7,
+                     "google/gemini-1.5-pro", "exp-42"),
+                )
+                # Row with NULL model (genuinely legacy)
+                conn.execute(
+                    """INSERT INTO normalized_attributes
+                       (image_id, composition, subject_strength, visual_appeal,
+                        sharpness, exposure_balance, noise_level)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    ("legacy_img", 0.5, 0.5, 0.5, 0.5, 0.5, 0.5),
+                )
+                conn.execute("""
+                    CREATE TABLE image_metadata (
+                        image_id TEXT PRIMARY KEY,
+                        date_taken TEXT,
+                        latitude REAL,
+                        longitude REAL,
+                        description TEXT,
+                        location_name TEXT,
+                        location_country TEXT
+                    )
+                """)
+                conn.commit()
+
+            cache = Cache(db_path)
+
+            # Explicit model identity must be preserved
+            gemini = cache.get_attributes(
+                "gemini_img", "google/gemini-1.5-pro", "exp-42"
+            )
+            assert gemini is not None, "Explicit model identity must survive migration"
+            assert gemini.model_name == "google/gemini-1.5-pro"
+            assert gemini.model_version == "exp-42"
+
+            # It must NOT appear under the cloud identity
+            cloud_gemini = cache.get_attributes(
+                "gemini_img", "anthropic/claude-3.5-sonnet", "cloud-v1"
+            )
+            assert cloud_gemini is None, "Explicit model must not be relabeled as cloud"
+
+            # NULL model row should be normalized to cloud identity
+            legacy = cache.get_attributes(
+                "legacy_img", "anthropic/claude-3.5-sonnet", "cloud-v1"
+            )
+            assert legacy is not None, "NULL model row should become cloud identity"
+
     def test_migration_is_idempotent(self):
         """Running migration on already-migrated DB should be safe."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,229 @@
+"""Tests for inference abstractions."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from photo_score.inference.base import InferenceClient
+from photo_score.inference.errors import (
+    InferenceError,
+    CloudInferenceError,
+    LocalInferenceError,
+    ModelNotAvailableError,
+    HardwareInsufficientError,
+)
+from photo_score.inference.parsing import extract_json_from_response
+
+
+class TestErrorHierarchy:
+    """Tests for inference error hierarchy."""
+
+    def test_cloud_error_is_inference_error(self):
+        assert issubclass(CloudInferenceError, InferenceError)
+
+    def test_local_error_is_inference_error(self):
+        assert issubclass(LocalInferenceError, InferenceError)
+
+    def test_model_not_available_is_local_error(self):
+        assert issubclass(ModelNotAvailableError, LocalInferenceError)
+
+    def test_hardware_insufficient_is_local_error(self):
+        assert issubclass(HardwareInsufficientError, LocalInferenceError)
+
+    def test_openrouter_error_is_cloud_error(self):
+        from photo_score.inference.client import OpenRouterError
+
+        assert issubclass(OpenRouterError, CloudInferenceError)
+
+
+class TestProtocol:
+    """Tests for InferenceClient protocol."""
+
+    def test_openrouter_satisfies_protocol(self):
+        """OpenRouterClient should satisfy InferenceClient protocol."""
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from photo_score.inference.client import OpenRouterClient
+
+            client = OpenRouterClient(
+                api_key="test-key",
+                model_name="test/model",
+                model_version="1.0",
+            )
+            assert isinstance(client, InferenceClient)
+            assert client.model_name == "test/model"
+            assert client.model_version == "1.0"
+            client.close()
+
+
+class TestFactory:
+    """Tests for create_inference_client factory."""
+
+    def test_factory_cloud_returns_openrouter(self):
+        from photo_score.inference.factory import create_inference_client
+
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            client = create_inference_client(
+                backend="cloud",
+                api_key="test-key",
+                model_name="test/model",
+                model_version="v1",
+            )
+            assert client.model_name == "test/model"
+            assert client.model_version == "v1"
+            client.close()
+
+    def test_factory_local_without_extras_raises(self):
+        """create_inference_client('local') should raise if extras not installed."""
+        from photo_score.inference.factory import create_inference_client
+
+        # QwenLocalClient imports torch, which won't be available in test env
+        # This should raise LocalInferenceError or ImportError-derived error
+        with pytest.raises((LocalInferenceError, ImportError)):
+            create_inference_client(backend="local")
+
+    def test_factory_unknown_backend_raises(self):
+        from photo_score.inference.factory import create_inference_client
+
+        with pytest.raises(ValueError, match="Unknown backend"):
+            create_inference_client(backend="invalid")
+
+
+class TestJsonParsing:
+    """Tests for extract_json_from_response."""
+
+    def test_plain_json(self):
+        result = extract_json_from_response('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_markdown_code_block(self):
+        result = extract_json_from_response('```json\n{"key": "value"}\n```')
+        assert result == {"key": "value"}
+
+    def test_text_before_json(self):
+        result = extract_json_from_response('Here is the result: {"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_text_after_json(self):
+        result = extract_json_from_response('{"key": "value"} Hope this helps!')
+        assert result == {"key": "value"}
+
+    def test_nested_json(self):
+        result = extract_json_from_response('{"a": {"b": 1}}')
+        assert result == {"a": {"b": 1}}
+
+    def test_no_json_raises(self):
+        with pytest.raises(ValueError, match="No JSON found"):
+            extract_json_from_response("no json here")
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            extract_json_from_response("{broken json")
+
+
+class TestCalibration:
+    """Tests for local inference calibration."""
+
+    def test_identity_calibration_is_noop(self):
+        from photo_score.inference.local.calibration import (
+            CalibrationMap,
+            apply_calibration,
+        )
+        from photo_score.storage.models import NormalizedAttributes
+
+        identity = CalibrationMap(
+            composition=(1.0, 0.0),
+            subject_strength=(1.0, 0.0),
+            visual_appeal=(1.0, 0.0),
+            sharpness=(1.0, 0.0),
+            exposure_balance=(1.0, 0.0),
+            noise_level=(1.0, 0.0),
+        )
+        attrs = NormalizedAttributes(
+            image_id="test",
+            composition=0.7,
+            subject_strength=0.6,
+            visual_appeal=0.5,
+            sharpness=0.8,
+            exposure_balance=0.9,
+            noise_level=0.4,
+            model_name="test",
+            model_version="1.0",
+        )
+
+        result = apply_calibration(attrs, identity)
+        assert result.composition == pytest.approx(0.7)
+        assert result.sharpness == pytest.approx(0.8)
+
+    def test_calibration_clamps_to_unit(self):
+        from photo_score.inference.local.calibration import (
+            CalibrationMap,
+            apply_calibration,
+        )
+        from photo_score.storage.models import NormalizedAttributes
+
+        aggressive = CalibrationMap(
+            composition=(2.0, 0.5),  # Would produce >1.0
+            subject_strength=(1.0, -0.5),  # Would produce <0.0 for low values
+            visual_appeal=(1.0, 0.0),
+            sharpness=(1.0, 0.0),
+            exposure_balance=(1.0, 0.0),
+            noise_level=(1.0, 0.0),
+        )
+        attrs = NormalizedAttributes(
+            image_id="test",
+            composition=0.9,  # 2.0*0.9 + 0.5 = 2.3 -> clamped to 1.0
+            subject_strength=0.1,  # 1.0*0.1 - 0.5 = -0.4 -> clamped to 0.0
+            visual_appeal=0.5,
+            sharpness=0.5,
+            exposure_balance=0.5,
+            noise_level=0.5,
+            model_name="test",
+            model_version="1.0",
+        )
+
+        result = apply_calibration(attrs, aggressive)
+        assert result.composition == 1.0
+        assert result.subject_strength == 0.0
+
+    def test_default_calibration_scales_down(self):
+        from photo_score.inference.local.calibration import (
+            DEFAULT_CALIBRATION,
+            apply_calibration,
+        )
+        from photo_score.storage.models import NormalizedAttributes
+
+        attrs = NormalizedAttributes(
+            image_id="test",
+            composition=0.8,
+            subject_strength=0.8,
+            visual_appeal=0.8,
+            sharpness=0.8,
+            exposure_balance=0.8,
+            noise_level=0.8,
+            model_name="test",
+            model_version="1.0",
+        )
+
+        result = apply_calibration(attrs, DEFAULT_CALIBRATION)
+        # All slopes < 1.0, so all calibrated values should be lower
+        assert result.composition < 0.8
+        assert result.subject_strength < 0.8
+        assert result.visual_appeal < 0.8
+        assert result.sharpness < 0.8
+
+
+class TestConfigBackend:
+    """Tests for config schema backend field."""
+
+    def test_default_backend_is_cloud(self):
+        from photo_score.config.schema import ModelConfig
+
+        config = ModelConfig()
+        assert config.backend == "cloud"
+
+    def test_backend_can_be_set(self):
+        from photo_score.config.schema import ModelConfig
+
+        config = ModelConfig(backend="local")
+        assert config.backend == "local"

--- a/tests/test_sidecar_cache.py
+++ b/tests/test_sidecar_cache.py
@@ -275,13 +275,21 @@ class TestMigrationPreservesDesktopVisibility:
                 "'unknown' model row should be migrated to cloud identity"
             )
 
-            # Rows that already had explicit model_name keep their model_name
-            # but get model_version normalized (was 20241022, now cloud-v1)
+            # Rows with explicit model_name preserve their identity (not relabeled)
             cloud_row = cache.get_attributes(
-                "cloud_model", "anthropic/claude-3.5-sonnet", CLOUD_MODEL_VERSION
+                "cloud_model", "anthropic/claude-3.5-sonnet", "20241022"
             )
             assert cloud_row is not None, (
-                "Cloud model row should be migrated to cloud-v1 version"
+                "Explicit model identity must be preserved during migration"
+            )
+            assert cloud_row.model_version == "20241022"
+
+            # Such rows are NOT visible under the desktop cloud-v1 filter
+            desktop_cloud = cache.get_attributes(
+                "cloud_model", CLOUD_MODEL_NAME, CLOUD_MODEL_VERSION
+            )
+            assert desktop_cloud is None, (
+                "Explicit model_version must not be relabeled to cloud-v1"
             )
 
             # Legacy metadata should also be visible

--- a/tests/test_sidecar_cache.py
+++ b/tests/test_sidecar_cache.py
@@ -1,0 +1,325 @@
+"""Tests for sidecar cache-filtering behavior.
+
+These tests verify that the desktop sidecar's cache interaction patterns
+work correctly with the new composite-PK schema. They exercise the exact
+filter values that inference.py and sync.py use, without requiring FastAPI.
+"""
+
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from photo_score.storage.cache import Cache
+from photo_score.storage.models import ImageMetadata, NormalizedAttributes
+
+# Must match packages/desktop/sidecar/handlers/inference.py
+CLOUD_MODEL_NAME = "anthropic/claude-3.5-sonnet"
+CLOUD_MODEL_VERSION = "cloud-v1"
+
+# Must match packages/desktop/sidecar/handlers/sync.py
+SYNC_MODEL_NAME = "anthropic/claude-3.5-sonnet"
+SYNC_MODEL_VERSION = "cloud-v1"
+
+
+@pytest.fixture
+def temp_cache() -> Cache:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test_cache.db"
+        yield Cache(db_path)
+
+
+def _cloud_attrs(image_id: str, composition: float = 0.8, scored_at=None):
+    return NormalizedAttributes(
+        image_id=image_id,
+        composition=composition,
+        subject_strength=0.7,
+        visual_appeal=0.6,
+        sharpness=0.9,
+        exposure_balance=0.85,
+        noise_level=0.75,
+        model_name=CLOUD_MODEL_NAME,
+        model_version=CLOUD_MODEL_VERSION,
+        scored_at=scored_at,
+    )
+
+
+def _local_attrs(image_id: str, composition: float = 0.5, scored_at=None):
+    return NormalizedAttributes(
+        image_id=image_id,
+        composition=composition,
+        subject_strength=0.5,
+        visual_appeal=0.5,
+        sharpness=0.5,
+        exposure_balance=0.5,
+        noise_level=0.5,
+        model_name="local/qwen2-vl-2b-instruct",
+        model_version="1.0",
+        scored_at=scored_at,
+    )
+
+
+def _cli_cloud_attrs(image_id: str, composition: float = 0.7, scored_at=None):
+    """CLI cloud uses the same model_name but different model_version."""
+    return NormalizedAttributes(
+        image_id=image_id,
+        composition=composition,
+        subject_strength=0.6,
+        visual_appeal=0.5,
+        sharpness=0.8,
+        exposure_balance=0.8,
+        noise_level=0.7,
+        model_name="anthropic/claude-3.5-sonnet",
+        model_version="20241022",
+        scored_at=scored_at,
+    )
+
+
+class TestDesktopInferenceFiltering:
+    """Tests that the desktop inference handler's cache patterns work.
+
+    The sidecar inference.py filters all get_attributes calls by
+    CLOUD_MODEL_NAME + CLOUD_MODEL_VERSION to only show desktop cloud scores.
+    """
+
+    def test_desktop_cloud_score_visible(self, temp_cache):
+        """Desktop cloud scores should be visible with the sidecar's filter."""
+        attrs = _cloud_attrs("img1")
+        temp_cache.store_attributes(attrs)
+
+        result = temp_cache.get_attributes(
+            "img1", model_name=CLOUD_MODEL_NAME, model_version=CLOUD_MODEL_VERSION
+        )
+        assert result is not None
+        assert result.composition == 0.8
+
+    def test_local_score_invisible_to_desktop(self, temp_cache):
+        """Local scores should NOT appear when desktop filters by cloud identity."""
+        temp_cache.store_attributes(_local_attrs("img1"))
+
+        result = temp_cache.get_attributes(
+            "img1", model_name=CLOUD_MODEL_NAME, model_version=CLOUD_MODEL_VERSION
+        )
+        assert result is None
+
+    def test_cli_cloud_score_invisible_to_desktop(self, temp_cache):
+        """CLI cloud scores (different model_version) should NOT appear in desktop."""
+        temp_cache.store_attributes(_cli_cloud_attrs("img1"))
+
+        result = temp_cache.get_attributes(
+            "img1", model_name=CLOUD_MODEL_NAME, model_version=CLOUD_MODEL_VERSION
+        )
+        assert result is None
+
+    def test_all_three_backends_coexist(self, temp_cache):
+        """Desktop cloud, CLI cloud, and local can all coexist for same image."""
+        temp_cache.store_attributes(_cloud_attrs("img1", composition=0.9))
+        temp_cache.store_attributes(_cli_cloud_attrs("img1", composition=0.7))
+        temp_cache.store_attributes(_local_attrs("img1", composition=0.5))
+
+        desktop = temp_cache.get_attributes(
+            "img1", CLOUD_MODEL_NAME, CLOUD_MODEL_VERSION
+        )
+        cli_cloud = temp_cache.get_attributes(
+            "img1", "anthropic/claude-3.5-sonnet", "20241022"
+        )
+        local = temp_cache.get_attributes("img1", "local/qwen2-vl-2b-instruct", "1.0")
+
+        assert desktop.composition == 0.9
+        assert cli_cloud.composition == 0.7
+        assert local.composition == 0.5
+
+
+class TestDesktopSyncFiltering:
+    """Tests that the sync handler's cache patterns work.
+
+    sync.py calls list_unsynced_attributes(model_name=SYNC_MODEL_NAME,
+    model_version=SYNC_MODEL_VERSION) and mark_synced with full tuples.
+    """
+
+    def test_only_desktop_rows_in_push_batch(self, temp_cache):
+        """list_unsynced with sync filter should only return desktop cloud rows."""
+        now = datetime.now(timezone.utc)
+        temp_cache.store_attributes(_cloud_attrs("img1", scored_at=now))
+        temp_cache.store_attributes(_local_attrs("img2", scored_at=now))
+        temp_cache.store_attributes(_cli_cloud_attrs("img3", scored_at=now))
+
+        unsynced = temp_cache.list_unsynced_attributes(
+            model_name=SYNC_MODEL_NAME, model_version=SYNC_MODEL_VERSION
+        )
+
+        ids = [a.image_id for a in unsynced]
+        assert "img1" in ids
+        assert "img2" not in ids  # local — excluded
+        assert "img3" not in ids  # CLI cloud — excluded
+
+    def test_mark_synced_tuple_only_marks_target(self, temp_cache):
+        """mark_synced with tuple should only mark the specific desktop row."""
+        now = datetime.now(timezone.utc)
+        temp_cache.store_attributes(_cloud_attrs("img1", scored_at=now))
+        temp_cache.store_attributes(_local_attrs("img1", scored_at=now))
+
+        temp_cache.mark_synced([("img1", SYNC_MODEL_NAME, SYNC_MODEL_VERSION)])
+
+        # Desktop row is synced
+        desktop_unsynced = temp_cache.list_unsynced_attributes(
+            model_name=SYNC_MODEL_NAME, model_version=SYNC_MODEL_VERSION
+        )
+        assert len(desktop_unsynced) == 0
+
+        # Local row is still unsynced
+        local_unsynced = temp_cache.list_unsynced_attributes(
+            model_name="local/qwen2-vl-2b-instruct", model_version="1.0"
+        )
+        assert len(local_unsynced) == 1
+
+    def test_metadata_filtered_by_model_for_sync(self, temp_cache):
+        """list_all_metadata_for with model filter should match sync behavior."""
+        cloud_meta = ImageMetadata(description="Cloud desc")
+        local_meta = ImageMetadata(description="Local desc")
+
+        temp_cache.store_metadata("img1", cloud_meta, model_name=SYNC_MODEL_NAME)
+        temp_cache.store_metadata(
+            "img1", local_meta, model_name="local/qwen2-vl-2b-instruct"
+        )
+
+        result = temp_cache.list_all_metadata_for(["img1"], model_name=SYNC_MODEL_NAME)
+        assert len(result) == 1
+        assert result["img1"].description == "Cloud desc"
+
+
+class TestMigrationPreservesDesktopVisibility:
+    """Tests that migrated legacy rows are visible to the desktop sidecar."""
+
+    def test_migrated_rows_visible_with_desktop_filter(self):
+        """Legacy single-PK rows should be visible after migration with desktop filter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "legacy.db"
+
+            import sqlite3
+
+            with sqlite3.connect(db_path) as conn:
+                conn.execute("""
+                    CREATE TABLE normalized_attributes (
+                        image_id TEXT PRIMARY KEY,
+                        composition REAL NOT NULL,
+                        subject_strength REAL NOT NULL,
+                        visual_appeal REAL NOT NULL,
+                        sharpness REAL NOT NULL,
+                        exposure_balance REAL NOT NULL,
+                        noise_level REAL NOT NULL,
+                        model_name TEXT,
+                        model_version TEXT
+                    )
+                """)
+                # Row with NULL model fields (earliest schema)
+                conn.execute(
+                    "INSERT INTO normalized_attributes VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL)",
+                    ("null_model", 0.8, 0.7, 0.6, 0.9, 0.85, 0.75),
+                )
+                # Row with 'unknown' model fields (intermediate state)
+                conn.execute(
+                    "INSERT INTO normalized_attributes VALUES (?, ?, ?, ?, ?, ?, ?, 'unknown', 'unknown')",
+                    ("unknown_model", 0.5, 0.5, 0.5, 0.5, 0.5, 0.5),
+                )
+                # Row with actual cloud model name (already correct)
+                conn.execute(
+                    "INSERT INTO normalized_attributes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        "cloud_model",
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        "anthropic/claude-3.5-sonnet",
+                        "20241022",
+                    ),
+                )
+                conn.execute("""
+                    CREATE TABLE image_metadata (
+                        image_id TEXT PRIMARY KEY,
+                        date_taken TEXT,
+                        latitude REAL,
+                        longitude REAL,
+                        description TEXT,
+                        location_name TEXT,
+                        location_country TEXT
+                    )
+                """)
+                conn.execute(
+                    "INSERT INTO image_metadata (image_id, description) VALUES (?, ?)",
+                    ("null_model", "Legacy photo"),
+                )
+                conn.commit()
+
+            # Migration runs on Cache init
+            cache = Cache(db_path)
+
+            # NULL-model rows should now be visible with desktop filter
+            null_row = cache.get_attributes(
+                "null_model", CLOUD_MODEL_NAME, CLOUD_MODEL_VERSION
+            )
+            assert null_row is not None, (
+                "NULL model_name row should be migrated to cloud identity"
+            )
+            assert null_row.composition == 0.8
+
+            # 'unknown' rows should also be migrated to cloud identity
+            unknown_row = cache.get_attributes(
+                "unknown_model", CLOUD_MODEL_NAME, CLOUD_MODEL_VERSION
+            )
+            assert unknown_row is not None, (
+                "'unknown' model row should be migrated to cloud identity"
+            )
+
+            # Rows that already had explicit model_name keep their model_name
+            # but get model_version normalized (was 20241022, now cloud-v1)
+            cloud_row = cache.get_attributes(
+                "cloud_model", "anthropic/claude-3.5-sonnet", CLOUD_MODEL_VERSION
+            )
+            assert cloud_row is not None, (
+                "Cloud model row should be migrated to cloud-v1 version"
+            )
+
+            # Legacy metadata should also be visible
+            meta = cache.get_metadata("null_model", model_name=CLOUD_MODEL_NAME)
+            assert meta is not None
+            assert meta.description == "Legacy photo"
+
+    def test_migrated_rows_appear_in_sync_push(self):
+        """Migrated rows should appear in sync push (unsynced with correct identity)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "legacy_sync.db"
+
+            import sqlite3
+
+            with sqlite3.connect(db_path) as conn:
+                conn.execute("""
+                    CREATE TABLE normalized_attributes (
+                        image_id TEXT PRIMARY KEY,
+                        composition REAL NOT NULL,
+                        subject_strength REAL NOT NULL,
+                        visual_appeal REAL NOT NULL,
+                        sharpness REAL NOT NULL,
+                        exposure_balance REAL NOT NULL,
+                        noise_level REAL NOT NULL,
+                        model_name TEXT,
+                        model_version TEXT
+                    )
+                """)
+                conn.execute(
+                    "INSERT INTO normalized_attributes VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL)",
+                    ("sync_me", 0.8, 0.7, 0.6, 0.9, 0.85, 0.75),
+                )
+                conn.commit()
+
+            cache = Cache(db_path)
+
+            unsynced = cache.list_unsynced_attributes(
+                model_name=SYNC_MODEL_NAME, model_version=SYNC_MODEL_VERSION
+            )
+            ids = [a.image_id for a in unsynced]
+            assert "sync_me" in ids

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,24 @@ revision = 1
 requires-python = "==3.11.*"
 
 [[package]]
+name = "accelerate"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/46/02ac5e262d4af18054b3e922b2baedbb2a03289ee792162de60a865defc5/accelerate-1.13.0-py3-none-any.whl", hash = "sha256:cf1a3efb96c18f7b152eb0fa7490f3710b19c3f395699358f08decca2b8b62e0", size = 383744 },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -34,12 +52,69 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "17.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/eb/abca886df3a091bc406feb5ff71b4c4f426beaae6b71b9697264ce8c7211/av-17.0.0.tar.gz", hash = "sha256:c53685df73775a8763c375c7b2d62a6cb149d992a26a4b098204da42ade8c3df", size = 4410769 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/fb/55e3b5b5d1fc61466292f26fbcbabafa2642f378dc48875f8f554591e1a4/av-17.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ed4013fac77c309a4a68141dcf6148f1821bb1073a36d4289379762a6372f711", size = 23238424 },
+    { url = "https://files.pythonhosted.org/packages/52/03/9ace1acc08bc9ae38c14bf3a4b1360e995e4d999d1d33c2cbd7c9e77582a/av-17.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:e44b6c83e9f3be9f79ee87d0b77a27cea9a9cd67bd630362c86b7e56a748dfbb", size = 18709043 },
+    { url = "https://files.pythonhosted.org/packages/00/c0/637721f3cd5bb8bd16105a1a08efd781fc12f449931bdb3a4d0cfd63fa55/av-17.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b440da6ac47da0629d509316f24bcd858f33158dbdd0f1b7293d71e99beb26de", size = 34018780 },
+    { url = "https://files.pythonhosted.org/packages/d2/59/d19bc3257dd985d55337d7f0414c019414b97e16cd3690ebf9941a847543/av-17.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1060cba85f97f4a337311169d92c0b5e143452cfa5ca0e65fa499d7955e8592e", size = 36358757 },
+    { url = "https://files.pythonhosted.org/packages/52/6c/a1f4f2677bae6f2ade7a8a18e90ebdcf70690c9b1c4e40e118aa30fa313f/av-17.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:deda202e6021cfc7ba3e816897760ec5431309d59a4da1f75df3c0e9413d71e7", size = 35195281 },
+    { url = "https://files.pythonhosted.org/packages/90/ea/52b0fc6f69432c7bf3f5fbe6f707113650aa40a1a05b9096ffc2bba4f77d/av-17.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ffaf266a1a9c2148072de0a4b5ae98061465178d2cfaa69ee089761149342974", size = 37444817 },
+    { url = "https://files.pythonhosted.org/packages/34/ad/d2172966282cb8f146c13b6be7416efefde74186460c5e1708ddfc13dba6/av-17.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:45a35a40b2875bf2f98de7c952d74d960f92f319734e6d28e03b4c62a49e6f49", size = 28888553 },
+    { url = "https://files.pythonhosted.org/packages/b0/bb/c5a4c4172c514d631fb506e6366b503576b8c7f29809cf42aca73e28ff01/av-17.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:3d32e9b5c5bbcb872a0b6917b352a1db8a42142237826c9b49a36d5dbd9e9c26", size = 21916910 },
+]
+
+[[package]]
+name = "bitsandbytes"
+version = "0.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/7d/f1fe0992334b18cd8494f89aeec1dcc674635584fcd9f115784fea3a1d05/bitsandbytes-0.49.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:87be5975edeac5396d699ecbc39dfc47cf2c026daaf2d5852a94368611a6823f", size = 131940 },
+    { url = "https://files.pythonhosted.org/packages/29/71/acff7af06c818664aa87ff73e17a52c7788ad746b72aea09d3cb8e424348/bitsandbytes-0.49.2-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:2fc0830c5f7169be36e60e11f2be067c8f812dfcb829801a8703735842450750", size = 31442815 },
+    { url = "https://files.pythonhosted.org/packages/19/57/3443d6f183436fbdaf5000aac332c4d5ddb056665d459244a5608e98ae92/bitsandbytes-0.49.2-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:54b771f06e1a3c73af5c7f16ccf0fc23a846052813d4b008d10cb6e017dd1c8c", size = 60651714 },
+    { url = "https://files.pythonhosted.org/packages/b6/d4/501655842ad6771fb077f576d78cbedb5445d15b1c3c91343ed58ca46f0e/bitsandbytes-0.49.2-py3-none-win_amd64.whl", hash = "sha256:2e0ddd09cd778155388023cbe81f00afbb7c000c214caef3ce83386e7144df7d", size = 55372289 },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6", size = 143363 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/28/ff6f234e628a2de61c458be2779cb182bc03f6eec12200d4a525bbfc9741/charset_normalizer-3.4.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:82060f995ab5003a2d6e0f4ad29065b7672b6593c8c63559beefe5b443242c3e", size = 293582 },
+    { url = "https://files.pythonhosted.org/packages/1c/b7/b1a117e5385cbdb3205f6055403c2a2a220c5ea80b8716c324eaf75c5c95/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60c74963d8350241a79cb8feea80e54d518f72c26db618862a8f53e5023deaf9", size = 197240 },
+    { url = "https://files.pythonhosted.org/packages/a1/5f/2574f0f09f3c3bc1b2f992e20bce6546cb1f17e111c5be07308dc5427956/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e4333fb15c83f7d1482a76d45a0818897b3d33f00efd215528ff7c51b8e35d", size = 217363 },
+    { url = "https://files.pythonhosted.org/packages/4a/d1/0ae20ad77bc949ddd39b51bf383b6ca932f2916074c95cad34ae465ab71f/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc72863f4d9aba2e8fd9085e63548a324ba706d2ea2c83b260da08a59b9482de", size = 212994 },
+    { url = "https://files.pythonhosted.org/packages/60/ac/3233d262a310c1b12633536a07cde5ddd16985e6e7e238e9f3f9423d8eb9/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73", size = 204697 },
+    { url = "https://files.pythonhosted.org/packages/25/3c/8a18fc411f085b82303cfb7154eed5bd49c77035eb7608d049468b53f87c/charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:0c173ce3a681f309f31b87125fecec7a5d1347261ea11ebbb856fa6006b23c8c", size = 191673 },
+    { url = "https://files.pythonhosted.org/packages/ff/a7/11cfe61d6c5c5c7438d6ba40919d0306ed83c9ab957f3d4da2277ff67836/charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c907cdc8109f6c619e6254212e794d6548373cc40e1ec75e6e3823d9135d29cc", size = 201120 },
+    { url = "https://files.pythonhosted.org/packages/b5/10/cf491fa1abd47c02f69687046b896c950b92b6cd7337a27e6548adbec8e4/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:404a1e552cf5b675a87f0651f8b79f5f1e6fd100ee88dc612f89aa16abd4486f", size = 200911 },
+    { url = "https://files.pythonhosted.org/packages/28/70/039796160b48b18ed466fde0af84c1b090c4e288fae26cd674ad04a2d703/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e3c701e954abf6fc03a49f7c579cc80c2c6cc52525340ca3186c41d3f33482ef", size = 192516 },
+    { url = "https://files.pythonhosted.org/packages/ff/34/c56f3223393d6ff3124b9e78f7de738047c2d6bc40a4f16ac0c9d7a1cb3c/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7a6967aaf043bceabab5412ed6bd6bd26603dae84d5cb75bf8d9a74a4959d398", size = 218795 },
+    { url = "https://files.pythonhosted.org/packages/e8/3b/ce2d4f86c5282191a041fdc5a4ce18f1c6bd40a5bd1f74cf8625f08d51c1/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5feb91325bbceade6afab43eb3b508c63ee53579fe896c77137ded51c6b6958e", size = 201833 },
+    { url = "https://files.pythonhosted.org/packages/3b/9b/b6a9f76b0fd7c5b5ec58b228ff7e85095370282150f0bd50b3126f5506d6/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:f820f24b09e3e779fe84c3c456cb4108a7aa639b0d1f02c28046e11bfcd088ed", size = 213920 },
+    { url = "https://files.pythonhosted.org/packages/ae/98/7bc23513a33d8172365ed30ee3a3b3fe1ece14a395e5fc94129541fc6003/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b35b200d6a71b9839a46b9b7fff66b6638bb52fc9658aa58796b0326595d3021", size = 206951 },
+    { url = "https://files.pythonhosted.org/packages/32/73/c0b86f3d1458468e11aec870e6b3feac931facbe105a894b552b0e518e79/charset_normalizer-3.4.6-cp311-cp311-win32.whl", hash = "sha256:9ca4c0b502ab399ef89248a2c84c54954f77a070f28e546a85e91da627d1301e", size = 143703 },
+    { url = "https://files.pythonhosted.org/packages/c6/e3/76f2facfe8eddee0bbd38d2594e709033338eae44ebf1738bcefe0a06185/charset_normalizer-3.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:a9e68c9d88823b274cf1e72f28cb5dc89c990edf430b0bfd3e2fb0785bfeabf4", size = 153857 },
+    { url = "https://files.pythonhosted.org/packages/e2/dc/9abe19c9b27e6cd3636036b9d1b387b78c40dedbf0b47f9366737684b4b0/charset_normalizer-3.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:97d0235baafca5f2b09cf332cc275f021e694e8362c6bb9c96fc9a0eb74fc316", size = 142751 },
+    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455 },
 ]
 
 [[package]]
@@ -91,6 +166,69 @@ toml = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273 },
+    { url = "https://files.pythonhosted.org/packages/e9/94/2748597f47bb1600cd466b20cab4159f1530a3a33fe7f70fee199b3abb9e/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1eba9504ac70667dd48313395fe05157518fd6371b532790e96fbb31bbb5a5e1", size = 6313924 },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/66/0c02bd330e7d976f83fa68583d6198d76f23581bcbb5c0e98a6148f326e5/cuda_pathfinder-1.5.0-py3-none-any.whl", hash = "sha256:498f90a9e9de36044a7924742aecce11c50c49f735f1bc53e05aa46de9ea4110", size = 49739 },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364 },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
@@ -106,12 +244,46 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759 },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505 },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/08/23c84a26716382c89151b5b447b4beb19e3345f3a93d3b73009a71a57ad3/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea", size = 672357 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/86/b40b83a2ff03ef05c4478d2672b1fc2b9683ff870e2b25f4f3af240f2e7b/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5", size = 3800339 },
+    { url = "https://files.pythonhosted.org/packages/64/2e/af4475c32b4378b0e92a587adb1aa3ec53e3450fd3e5fe0372a874531c00/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a", size = 3559664 },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c", size = 4217422 },
+    { url = "https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271", size = 3992847 },
+    { url = "https://files.pythonhosted.org/packages/2d/ef/e80815061abff54697239803948abc665c6b1d237102c174f4f7a9a5ffc5/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2", size = 4193843 },
+    { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751 },
+    { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149 },
+    { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426 },
 ]
 
 [[package]]
@@ -158,6 +330,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/2a/a847fd02261cd051da218baf99f90ee7c7040c109a01833db4f838f25256/huggingface_hub-1.8.0.tar.gz", hash = "sha256:c5627b2fd521e00caf8eff4ac965ba988ea75167fad7ee72e17f9b7183ec63f3", size = 735839 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ae/8a3a16ea4d202cb641b51d2681bdd3d482c1c592d7570b3fa264730829ce/huggingface_hub-1.8.0-py3-none-any.whl", hash = "sha256:d3eb5047bd4e33c987429de6020d4810d38a5bef95b3b40df9b17346b7f353f2", size = 625208 },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -176,6 +368,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -188,12 +392,224 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631 },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058 },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287 },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940 },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887 },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692 },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471 },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923 },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572 },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077 },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876 },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504 },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/51/5093a2df15c4dc19da3f79d1021e891f5dcf1d9d1db6ba38891d5590f3fe/numpy-2.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:33b3bf58ee84b172c067f56aeadc7ee9ab6de69c5e800ab5b10295d54c581adb", size = 16957183 },
+    { url = "https://files.pythonhosted.org/packages/b5/7c/c061f3de0630941073d2598dc271ac2f6cbcf5c83c74a5870fea07488333/numpy-2.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8ba7b51e71c05aa1f9bc3641463cd82308eab40ce0d5c7e1fd4038cbf9938147", size = 14968734 },
+    { url = "https://files.pythonhosted.org/packages/ef/27/d26c85cbcd86b26e4f125b0668e7a7c0542d19dd7d23ee12e87b550e95b5/numpy-2.4.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a1988292870c7cb9d0ebb4cc96b4d447513a9644801de54606dc7aabf2b7d920", size = 5475288 },
+    { url = "https://files.pythonhosted.org/packages/2b/09/3c4abbc1dcd8010bf1a611d174c7aa689fc505585ec806111b4406f6f1b1/numpy-2.4.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:23b46bb6d8ecb68b58c09944483c135ae5f0e9b8d8858ece5e4ead783771d2a9", size = 6805253 },
+    { url = "https://files.pythonhosted.org/packages/21/bc/e7aa3f6817e40c3f517d407742337cbb8e6fc4b83ce0b55ab780c829243b/numpy-2.4.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a016db5c5dba78fa8fe9f5d80d6708f9c42ab087a739803c0ac83a43d686a470", size = 15969479 },
+    { url = "https://files.pythonhosted.org/packages/78/51/9f5d7a41f0b51649ddf2f2320595e15e122a40610b233d51928dd6c92353/numpy-2.4.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:715de7f82e192e8cae5a507a347d97ad17598f8e026152ca97233e3666daaa71", size = 16901035 },
+    { url = "https://files.pythonhosted.org/packages/64/6e/b221dd847d7181bc5ee4857bfb026182ef69499f9305eb1371cbb1aea626/numpy-2.4.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2ddb7919366ee468342b91dea2352824c25b55814a987847b6c52003a7c97f15", size = 17325657 },
+    { url = "https://files.pythonhosted.org/packages/eb/b8/8f3fd2da596e1063964b758b5e3c970aed1949a05200d7e3d46a9d46d643/numpy-2.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a315e5234d88067f2d97e1f2ef670a7569df445d55400f1e33d117418d008d52", size = 18635512 },
+    { url = "https://files.pythonhosted.org/packages/5c/24/2993b775c37e39d2f8ab4125b44337ab0b2ba106c100980b7c274a22bee7/numpy-2.4.3-cp311-cp311-win32.whl", hash = "sha256:2b3f8d2c4589b1a2028d2a770b0fc4d1f332fb5e01521f4de3199a896d158ddd", size = 6238100 },
+    { url = "https://files.pythonhosted.org/packages/76/1d/edccf27adedb754db7c4511d5eac8b83f004ae948fe2d3509e8b78097d4c/numpy-2.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:77e76d932c49a75617c6d13464e41203cd410956614d0a0e999b25e9e8d27eec", size = 12609816 },
+    { url = "https://files.pythonhosted.org/packages/92/82/190b99153480076c8dce85f4cfe7d53ea84444145ffa54cb58dcd460d66b/numpy-2.4.3-cp311-cp311-win_arm64.whl", hash = "sha256:eb610595dd91560905c132c709412b512135a60f1851ccbd2c959e136431ff67", size = 10485757 },
+    { url = "https://files.pythonhosted.org/packages/64/e4/4dab9fb43c83719c29241c535d9e07be73bea4bc0c6686c5816d8e1b6689/numpy-2.4.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c6b124bfcafb9e8d3ed09130dbee44848c20b3e758b6bbf006e641778927c028", size = 16834892 },
+    { url = "https://files.pythonhosted.org/packages/c9/29/f8b6d4af90fed3dfda84ebc0df06c9833d38880c79ce954e5b661758aa31/numpy-2.4.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:76dbb9d4e43c16cf9aa711fcd8de1e2eeb27539dcefb60a1d5e9f12fae1d1ed8", size = 14893070 },
+    { url = "https://files.pythonhosted.org/packages/9a/04/a19b3c91dbec0a49269407f15d5753673a09832daed40c45e8150e6fa558/numpy-2.4.3-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:29363fbfa6f8ee855d7569c96ce524845e3d726d6c19b29eceec7dd555dab152", size = 5399609 },
+    { url = "https://files.pythonhosted.org/packages/79/34/4d73603f5420eab89ea8a67097b31364bf7c30f811d4dd84b1659c7476d9/numpy-2.4.3-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:bc71942c789ef415a37f0d4eab90341425a00d538cd0642445d30b41023d3395", size = 6714355 },
+    { url = "https://files.pythonhosted.org/packages/58/ad/1100d7229bb248394939a12a8074d485b655e8ed44207d328fdd7fcebc7b/numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e58765ad74dcebd3ef0208a5078fba32dc8ec3578fe84a604432950cd043d79", size = 15800434 },
+    { url = "https://files.pythonhosted.org/packages/0c/fd/16d710c085d28ba4feaf29ac60c936c9d662e390344f94a6beaa2ac9899b/numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e236dbda4e1d319d681afcbb136c0c4a8e0f1a5c58ceec2adebb547357fe857", size = 16729409 },
+    { url = "https://files.pythonhosted.org/packages/57/a7/b35835e278c18b85206834b3aa3abe68e77a98769c59233d1f6300284781/numpy-2.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b42639cdde6d24e732ff823a3fa5b701d8acad89c4142bc1d0bd6dc85200ba5", size = 12504685 },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.0.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226 },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236 },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827 },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597 },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200 },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449 },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060 },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632 },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.19.0.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201 },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321 },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554 },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489 },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672 },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992 },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106 },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258 },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760 },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980 },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568 },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937 },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277 },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119 },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.28.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677 },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177 },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933 },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748 },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947 },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546 },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047 },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878 },
 ]
 
 [[package]]
@@ -224,6 +640,14 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+local = [
+    { name = "accelerate" },
+    { name = "bitsandbytes" },
+    { name = "huggingface-hub" },
+    { name = "qwen-vl-utils" },
+    { name = "torch" },
+    { name = "transformers" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -238,17 +662,23 @@ sidecar = [
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", marker = "extra == 'local'", specifier = ">=0.25.0" },
+    { name = "bitsandbytes", marker = "extra == 'local'", specifier = ">=0.41.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "huggingface-hub", marker = "extra == 'local'", specifier = ">=0.20.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pillow-heif", specifier = ">=0.13.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "qwen-vl-utils", marker = "extra == 'local'", specifier = ">=0.0.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "torch", marker = "extra == 'local'", specifier = ">=2.1.0" },
+    { name = "transformers", marker = "extra == 'local'", specifier = ">=4.45.0" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "local"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -317,6 +747,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090 },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859 },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560 },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997 },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972 },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266 },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737 },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617 },
 ]
 
 [[package]]
@@ -433,6 +879,60 @@ wheels = [
 ]
 
 [[package]]
+name = "qwen-vl-utils"
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/b1/ad4fc2260a3badd278b38d642f3b987412f1f6682f0ef2b31b0572d5caa8/qwen_vl_utils-0.0.14.tar.gz", hash = "sha256:9c7cad5ae803b3a10f8bb7194deb12aeacdd032f92f4224e880c73587a7346ad", size = 8453 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/43/80f67e0336cb2fc725f8e06f7fe35c1d0fe946f4d2b8b2175e797e07349e/qwen_vl_utils-0.0.14-py3-none-any.whl", hash = "sha256:5e28657bfd031e56bd447c5901b58ddfc3835285ed100f4c56580e0ade054e96", size = 8120 },
+]
+
+[[package]]
+name = "regex"
+version = "2026.2.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/71/41455aa99a5a5ac1eaf311f5d8efd9ce6433c03ac1e0962de163350d0d97/regex-2026.2.28.tar.gz", hash = "sha256:a729e47d418ea11d03469f321aaf67cdee8954cde3ff2cf8403ab87951ad10f2", size = 415184 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/db/8cbfd0ba3f302f2d09dd0019a9fcab74b63fee77a76c937d0e33161fb8c1/regex-2026.2.28-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e621fb7c8dc147419b28e1702f58a0177ff8308a76fa295c71f3e7827849f5d9", size = 488462 },
+    { url = "https://files.pythonhosted.org/packages/5d/10/ccc22c52802223f2368731964ddd117799e1390ffc39dbb31634a83022ee/regex-2026.2.28-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0d5bef2031cbf38757a0b0bc4298bb4824b6332d28edc16b39247228fbdbad97", size = 290774 },
+    { url = "https://files.pythonhosted.org/packages/62/b9/6796b3bf3101e64117201aaa3a5a030ec677ecf34b3cd6141b5d5c6c67d5/regex-2026.2.28-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bcb399ed84eabf4282587ba151f2732ad8168e66f1d3f85b1d038868fe547703", size = 288724 },
+    { url = "https://files.pythonhosted.org/packages/9c/02/291c0ae3f3a10cea941d0f5366da1843d8d1fa8a25b0671e20a0e454bb38/regex-2026.2.28-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c1b34dfa72f826f535b20712afa9bb3ba580020e834f3c69866c5bddbf10098", size = 791924 },
+    { url = "https://files.pythonhosted.org/packages/0f/57/f0235cc520d9672742196c5c15098f8f703f2758d48d5a7465a56333e496/regex-2026.2.28-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:851fa70df44325e1e4cdb79c5e676e91a78147b1b543db2aec8734d2add30ec2", size = 860095 },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/393c94cbedda79a0f5f2435ebd01644aba0b338d327eb24b4aa5b8d6c07f/regex-2026.2.28-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:516604edd17b1c2c3e579cf4e9b25a53bf8fa6e7cedddf1127804d3e0140ca64", size = 906583 },
+    { url = "https://files.pythonhosted.org/packages/2c/73/a72820f47ca5abf2b5d911d0407ba5178fc52cf9780191ed3a54f5f419a2/regex-2026.2.28-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7ce83654d1ab701cb619285a18a8e5a889c1216d746ddc710c914ca5fd71022", size = 800234 },
+    { url = "https://files.pythonhosted.org/packages/34/b3/6e6a4b7b31fa998c4cf159a12cbeaf356386fbd1a8be743b1e80a3da51e4/regex-2026.2.28-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f2791948f7c70bb9335a9102df45e93d428f4b8128020d85920223925d73b9e1", size = 772803 },
+    { url = "https://files.pythonhosted.org/packages/10/e7/5da0280c765d5a92af5e1cd324b3fe8464303189cbaa449de9a71910e273/regex-2026.2.28-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:03a83cc26aa2acda6b8b9dfe748cf9e84cbd390c424a1de34fdcef58961a297a", size = 781117 },
+    { url = "https://files.pythonhosted.org/packages/76/39/0b8d7efb256ae34e1b8157acc1afd8758048a1cf0196e1aec2e71fd99f4b/regex-2026.2.28-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:ec6f5674c5dc836994f50f1186dd1fafde4be0666aae201ae2fcc3d29d8adf27", size = 854224 },
+    { url = "https://files.pythonhosted.org/packages/21/ff/a96d483ebe8fe6d1c67907729202313895d8de8495569ec319c6f29d0438/regex-2026.2.28-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:50c2fc924749543e0eacc93ada6aeeb3ea5f6715825624baa0dccaec771668ae", size = 761898 },
+    { url = "https://files.pythonhosted.org/packages/89/bd/d4f2e75cb4a54b484e796017e37c0d09d8a0a837de43d17e238adf163f4e/regex-2026.2.28-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ba55c50f408fb5c346a3a02d2ce0ebc839784e24f7c9684fde328ff063c3cdea", size = 844832 },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/428a135cf5e15e4e11d1e696eb2bf968362f8ea8a5f237122e96bc2ae950/regex-2026.2.28-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:edb1b1b3a5576c56f08ac46f108c40333f222ebfd5cf63afdfa3aab0791ebe5b", size = 788347 },
+    { url = "https://files.pythonhosted.org/packages/a9/59/68691428851cf9c9c3707217ab1d9b47cfeec9d153a49919e6c368b9e926/regex-2026.2.28-cp311-cp311-win32.whl", hash = "sha256:948c12ef30ecedb128903c2c2678b339746eb7c689c5c21957c4a23950c96d15", size = 266033 },
+    { url = "https://files.pythonhosted.org/packages/42/8b/1483de1c57024e89296cbcceb9cccb3f625d416ddb46e570be185c9b05a9/regex-2026.2.28-cp311-cp311-win_amd64.whl", hash = "sha256:fd63453f10d29097cc3dc62d070746523973fb5aa1c66d25f8558bebd47fed61", size = 277978 },
+    { url = "https://files.pythonhosted.org/packages/a4/36/abec45dc6e7252e3dbc797120496e43bb5730a7abf0d9cb69340696a2f2d/regex-2026.2.28-cp311-cp311-win_arm64.whl", hash = "sha256:00f2b8d9615aa165fdff0a13f1a92049bfad555ee91e20d246a51aa0b556c60a", size = 270340 },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017 },
+]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -472,6 +972,37 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781 },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058 },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748 },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881 },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463 },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855 },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152 },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856 },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060 },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715 },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377 },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368 },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423 },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380 },
+]
+
+[[package]]
+name = "setuptools"
+version = "81.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021 },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -494,6 +1025,44 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353 },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275 },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472 },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736 },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835 },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673 },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818 },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195 },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982 },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245 },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069 },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263 },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429 },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363 },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786 },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133 },
+]
+
+[[package]]
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -508,6 +1077,74 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/eb/a7679c8ac85208706d27436e8d421dfa39d4c914dcf5fa8083a9305f58d9/tomli-2.3.0-cp311-cp311-win32.whl", hash = "sha256:00b5f5d95bbfc7d12f91ad8c593a1659b6387b43f054104cda404be6bda62456", size = 96445 },
     { url = "https://files.pythonhosted.org/packages/0a/fe/3d3420c4cb1ad9cb462fb52967080575f15898da97e21cb6f1361d505383/tomli-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:4dc4ce8483a5d429ab602f111a93a6ab1ed425eae3122032db7e9acf449451be", size = 107165 },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408 },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/0d/98b410492609e34a155fa8b121b55c7dca229f39636851c3a9ec20edea21/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4", size = 80529712 },
+    { url = "https://files.pythonhosted.org/packages/84/03/acea680005f098f79fd70c1d9d5ccc0cb4296ec2af539a0450108232fc0c/torch-2.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d91aac77f24082809d2c5a93f52a5f085032740a1ebc9252a7b052ef5a4fddc6", size = 419718178 },
+    { url = "https://files.pythonhosted.org/packages/8c/8b/d7be22fbec9ffee6cff31a39f8750d4b3a65d349a286cf4aec74c2375662/torch-2.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7aa2f9bbc6d4595ba72138026b2074be1233186150e9292865e04b7a63b8c67a", size = 530604548 },
+    { url = "https://files.pythonhosted.org/packages/d1/bd/9912d30b68845256aabbb4a40aeefeef3c3b20db5211ccda653544ada4b6/torch-2.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:73e24aaf8f36ab90d95cd1761208b2eb70841c2a9ca1a3f9061b39fc5331b708", size = 114519675 },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374 },
+]
+
+[[package]]
+name = "transformers"
+version = "5.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/88/ae8320064e32679a5429a2c9ebbc05c2bf32cefb6e076f9b07f6d685a9b4/transformers-5.3.0-py3-none-any.whl", hash = "sha256:50ac8c89c3c7033444fb3f9f53138096b997ebb70d4b5e50a2e810bf12d3d29a", size = 10661827 },
+]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190 },
+    { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640 },
 ]
 
 [[package]]
@@ -544,6 +1181,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Cache identity redesign**: Migrated `normalized_attributes` to composite PK `(image_id, model_name, model_version)` and `image_metadata` to `(image_id, model_name)` so cloud and local scores coexist without overwriting each other. Automatic migration from old single-PK schema preserves explicit model identities (e.g. `google/gemini-1.5-pro`) while normalizing legacy NULL/unknown rows to the canonical cloud identity.
- **Inference abstraction layer**: `InferenceClient` Protocol, error hierarchy (`InferenceError` → `Cloud`/`Local`), factory pattern (`create_inference_client(backend="cloud"|"local"|"auto")`), and shared utilities for image preprocessing and JSON parsing.
- **Local Qwen2-VL-2B client**: Lazy model loading, MPS (Apple Silicon) and CUDA support with 4-bit quantization, per-attribute calibration to align with cloud score distributions. Hardware detection and model download management via CLI.
- **Desktop sidecar isolation**: Inference and sync handlers filter by exact model identity (`anthropic/claude-3.5-sonnet` + `cloud-v1`) to prevent local or CLI cloud scores from leaking into the desktop experience.
- **Rescore filters by config**: `rescore` uses `config.model.name` + `config.model.version` for cache lookups, preventing cross-backend score/metadata mixing.

## Key fixes (post-initial review)

- Migration only normalizes NULL/empty/`"unknown"` rows to cloud identity; rows with explicit model names are preserved as-is (prevents data corruption)
- `rescore` uses `cached_attrs.model_name` for metadata lookup (prevents cross-backend metadata mismatch)
- `rescore` filters attributes by config model identity (prevents using wrong backend's scores)
- Sidecar sync tests updated to use model identity constants
- `bitsandbytes` gated with platform marker (only needed for CUDA, not available on x86_64 macOS)

## Test plan

- [x] `uv run pytest -v` — 108 root tests pass
- [x] `cd packages/desktop/sidecar && uv run pytest tests/ -v` — 13 sidecar tests pass
- [x] `uv run ruff check . && uv run ruff format --check .` — lint clean
- [x] CI green (all 8 checks)
- [x] Manual: `photo-score run --backend cloud` scores image via OpenRouter API
- [x] Manual: Second cloud run hits cache (0 API calls)
- [x] Manual: `photo-score rescore` uses config model identity for cache lookup
- [x] Manual: `photo-score hardware` shows detected capabilities
- [x] Manual: `photo-score models list` / `delete` work
- [x] Manual: Cache isolation — cloud and local rows coexist, neither overwrites
- [x] Manual: Desktop filter only sees cloud-scored attributes
- [x] Manual: Migration preserves explicit model identities (gemini, claude-20241022)
- [x] Manual: Migration normalizes NULL/unknown rows to cloud identity
- [ ] Manual: `photo-score run --backend local` with `[local]` extras + downloaded model (requires arm64 Python + GPU)
- [ ] Manual: `photo-score models download` (requires ~4GB HuggingFace download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)